### PR TITLE
Fix a bug in MithraMultithreadedQueueLoader.shutdownPool().

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/util/MithraMultiThreadedQueueLoader.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/util/MithraMultiThreadedQueueLoader.java
@@ -162,8 +162,11 @@ public class MithraMultiThreadedQueueLoader
     {
         synchronized(poolLock)
         {
-            executor.shutdown();
-            executor = null;
+            if (executor != null)
+            {
+                executor.shutdown();
+                executor = null;
+            }
         }
     }
 

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTransactionalList.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTransactionalList.java
@@ -909,6 +909,16 @@ public class TestTransactionalList extends MithraTestAbstract
     public void testMultithreadedQueueLoader()
     {
         MithraMultiThreadedQueueLoader loader = new MithraMultiThreadedQueueLoader(5);
+        //try shutting down the loader's pool before adding any items
+        try
+        {
+            loader.shutdownPool();
+        }
+        catch (Exception e)
+        {
+            fail("should not get here...");
+        }
+
         final OrderList firstList = new OrderList(OrderFinder.userId().eq(1));
         final OrderList secondList = new OrderList(OrderFinder.userId().eq(2));
         loader.addQueueItem(new MithraListQueueItem() {


### PR DESCRIPTION
Ensuring that the executor has been created before trying to shut it down. 