### PR TITLE
Disable batch updates on Oracle when doing optimistic locking

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/AbstractDatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/AbstractDatabaseType.java
@@ -993,6 +993,12 @@ public abstract class AbstractDatabaseType implements DatabaseType
         builder.append(")");
     }
 
+    @Override
+    public boolean canCombineOptimisticWithBatchUpdates()
+    {
+        return true;
+    }
+
     protected void startUpdateViaJoinQuery(String fullyQualifiedTableNameGenericSource, StringBuilder builder)
     {
         builder.append("update ").append(fullyQualifiedTableNameGenericSource);

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/DatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/DatabaseType.java
@@ -289,4 +289,6 @@ public interface DatabaseType extends CommonDatabaseType
             MithraObjectPortal mithraObjectPortal,
             String fullyQualifiedTableNameGenericSource,
             StringBuilder builder);
+
+    public boolean canCombineOptimisticWithBatchUpdates();
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/OracleDatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/OracleDatabaseType.java
@@ -39,10 +39,12 @@ public class OracleDatabaseType extends AbstractDatabaseType
     private static final int DUPLICATE_ERROR_CODE = 23001;
     public static final int MAX_CLAUSES = 240;
     private static final OracleDatabaseType instance = new OracleDatabaseType();
+    private static final OracleDatabaseType instance12 = new OracleDatabaseType(true);
     private static final Map<String, String> sqlToJavaTypes;
 
 
     private String tempSchema = null;
+    private boolean optimisticBatch = false;
 
     private static final int CODE_CONNECTION_INCONSISTENT = 17447;
     private static final int CODE_CONNECTION_CLOSED = 17008;
@@ -81,6 +83,11 @@ public class OracleDatabaseType extends AbstractDatabaseType
     /** Singleton */
     protected OracleDatabaseType()
     {
+    }
+
+    protected OracleDatabaseType(boolean optimisticBatch)
+    {
+        this.optimisticBatch = optimisticBatch;
     }
 
     @Override
@@ -172,6 +179,11 @@ public class OracleDatabaseType extends AbstractDatabaseType
     public static OracleDatabaseType getInstance()
     {
         return instance;
+    }
+
+    public static OracleDatabaseType getInstanceForOracle12()
+    {
+        return instance12;
     }
 
     public String getPerStatementLock(boolean lock)
@@ -586,5 +598,11 @@ public class OracleDatabaseType extends AbstractDatabaseType
     public int getNullableBooleanJavaSqlType()
     {
         return Types.NUMERIC;
+    }
+
+    @Override
+    public boolean canCombineOptimisticWithBatchUpdates()
+    {
+        return this.optimisticBatch;
     }
 }

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/CommonVendorTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/CommonVendorTestCases.java
@@ -18,15 +18,18 @@ package com.gs.fw.common.mithra.test;
 
 import com.gs.collections.impl.list.mutable.FastList;
 import com.gs.fw.common.mithra.*;
-import com.gs.fw.common.mithra.test.domain.Order;
-import com.gs.fw.common.mithra.test.domain.OrderDriverFinder;
-import com.gs.fw.common.mithra.test.domain.OrderFinder;
+import com.gs.fw.common.mithra.finder.Operation;
+import com.gs.fw.common.mithra.test.domain.*;
 import junit.framework.TestCase;
 
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.List;
 
 public class CommonVendorTestCases extends TestCase
 {
+    protected static SimpleDateFormat timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
     public void testRollback()
     {
         final List<Exception> exceptionsList = FastList.newList();
@@ -57,6 +60,64 @@ public class CommonVendorTestCases extends TestCase
             }
         }, 5);
         assertNotNull(OrderFinder.findOne(OrderFinder.orderId().eq(1000)));
+    }
+
+    public void testTimestampGranularity() throws Exception
+    {
+        TimestampConversionList list = new TimestampConversionList();
+        long start = timestampFormat.parse("2017-08-03 11:51:24").getTime();
+        for(int i=0;i<1000;i++)
+        {
+            TimestampConversion conversion = new TimestampConversion();
+            conversion.setId(1000+i);
+            conversion.setTimestampValueDB(new Timestamp(start + i*10));
+            conversion.setTimestampValueNone(new Timestamp(start + i*10));
+            conversion.setTimestampValueUTC(new Timestamp(start + i*10));
+            list.add(conversion);
+        }
+        list.insertAll();
+
+        MithraManagerProvider.getMithraManager().clearAllQueryCaches();
+
+        TimestampConversionList many = TimestampConversionFinder.findMany(TimestampConversionFinder.id().greaterThanEquals(1000));
+        many.setOrderBy(TimestampConversionFinder.id().ascendingOrderBy());
+
+        for(int i=0;i<1000;i++)
+        {
+            TimestampConversion timestampConversion = list.get(i);
+            assertEquals(start + i*10, timestampConversion.getTimestampValueDB().getTime());
+            assertEquals(start + i*10, timestampConversion.getTimestampValueNone().getTime());
+            assertEquals(start + i*10, timestampConversion.getTimestampValueUTC().getTime());
+        }
+
+        for(int i=0;i<1000;i++)
+        {
+            assertEquals(1000 + i, TimestampConversionFinder.findOneBypassCache(TimestampConversionFinder.timestampValueDB().eq(new Timestamp(start + i * 10))).getId());
+            assertEquals(1000 + i, TimestampConversionFinder.findOneBypassCache(TimestampConversionFinder.timestampValueNone().eq(new Timestamp(start + i * 10))).getId());
+            assertEquals(1000 + i, TimestampConversionFinder.findOneBypassCache(TimestampConversionFinder.timestampValueUTC().eq(new Timestamp(start + i * 10))).getId());
+        }
+    }
+
+    public void testOptimisticLocking()
+    {
+        final TestEodAcctIfPnlList list = TestEodAcctIfPnlFinder.findMany(TestEodAcctIfPnlFinder.all());
+        int size = list.size();
+
+        MithraManagerProvider.getMithraManager().executeTransactionalCommand(new TransactionalCommand<Object>()
+        {
+            @Override
+            public Object executeTransaction(MithraTransaction tx) throws Throwable
+            {
+                TestEodAcctIfPnlFinder.setTransactionModeReadCacheWithOptimisticLocking(tx);
+                for(TestEodAcctIfPnl pnl: list)
+                {
+                    pnl.setUserId("fred");
+                }
+                return null;
+            }
+        });
+
+        assertEquals(size, TestEodAcctIfPnlFinder.findMany(TestEodAcctIfPnlFinder.userId().eq("fred")).size());
     }
 
 }

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraOracleTestAbstract.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraOracleTestAbstract.java
@@ -103,6 +103,12 @@ public class MithraOracleTestAbstract extends MithraTestAbstract
       }
 
 
+    @Override
+    public Connection getConnection()
+    {
+        return OracleTestConnectionManager.getInstance().getConnection();
+    }
+
     protected void validateMithraResult(Operation op, String sql)
     {
         validateMithraResult(op, sql, 1);

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestDb2GeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestDb2GeneralTestCases.java
@@ -59,6 +59,16 @@ public class TestDb2GeneralTestCases extends MithraDb2TestAbstract
         super.tearDown();
     }
 
+    public void testTimestampGranularity2() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
     public void testSimpleOrder()
     {
         Assert.assertEquals(4, new ProductList(ProductFinder.all()).size());

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestMariaGeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestMariaGeneralTestCases.java
@@ -98,6 +98,16 @@ public class TestMariaGeneralTestCases extends MithraMariaTestAbstract
         super.tearDown();
     }
 
+    public void testTimestampGranularity() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
     public void testStringLikeEscapes()
     {
         new TestStringLike().testStringLikeEscapes();

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestMsSqlGeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestMsSqlGeneralTestCases.java
@@ -61,6 +61,16 @@ public class TestMsSqlGeneralTestCases extends MithraMsSqlTestAbstract
        super.tearDown();
     }
 
+    public void testTimestampGranularity2() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
     public void testStandardDeviation() throws ParseException
     {
         new TestStandardDeviation().testStdDevDouble();

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestPostgresGeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestPostgresGeneralTestCases.java
@@ -76,6 +76,16 @@ public class TestPostgresGeneralTestCases extends MithraPostgresTestAbstract
         new CommonVendorTestCases().testRollback();
     }
 
+    public void testTimestampGranularity() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
     public void testSimpleOrder()
     {
         Assert.assertEquals(4, new ProductList(ProductFinder.all()).size());

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestSybaseGeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestSybaseGeneralTestCases.java
@@ -63,6 +63,16 @@ public class TestSybaseGeneralTestCases extends MithraSybaseTestAbstract
        super.tearDown();
     }
 
+    public void testTimestampGranularity2() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
     public void testToCheckRepeatReadIsDisabled() throws Exception
     {
         new TestSybaseConnectionSetupForTests().testToCheckRepeatReadIsDisabled();

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestSybaseIqGeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestSybaseIqGeneralTestCases.java
@@ -63,6 +63,16 @@ public class TestSybaseIqGeneralTestCases extends MithraSybaseIqTestAbstract
         super.tearDown();
     }
 
+    public void testTimestampGranularity2() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
     public void testToCheckRepeatReadIsDisabled() throws Exception
     {
         new TestSybaseConnectionSetupForTests().testToCheckRepeatReadIsDisabled();


### PR DESCRIPTION
Add getInstanceForOracle12 to OracleDatabaseType that can do batch updates with optimistic locking