### PR TITLE
Bug fix for incrementing past data for bitemporal tables

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraAbstractDatabaseObject.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraAbstractDatabaseObject.java
@@ -50,6 +50,7 @@ import com.gs.fw.common.mithra.transaction.BatchUpdateOperation;
 import com.gs.fw.common.mithra.transaction.MultiUpdateOperation;
 import com.gs.fw.common.mithra.transaction.UpdateOperation;
 import com.gs.fw.common.mithra.util.*;
+import com.gs.reladomo.metadata.ReladomoClassMetaData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1982,24 +1983,7 @@ public abstract class MithraAbstractDatabaseObject
 
     private Extractor[] getPrimaryKeyFor(RelatedFinder finder)
     {
-        if (finder.getAsOfAttributes() == null)
-        {
-            return finder.getPrimaryKeyAttributes();
-        }
-        else
-        {
-            Extractor[] primKeyAttr = finder.getPrimaryKeyAttributes();
-            AsOfAttribute[] asOfKeyAttr = finder.getAsOfAttributes();
-
-            Extractor[] fullKey = new Extractor[primKeyAttr.length + asOfKeyAttr.length];
-            System.arraycopy(primKeyAttr, 0, fullKey, 0, primKeyAttr.length);
-
-            for (int i = 0; i < asOfKeyAttr.length; i++)
-            {
-                fullKey[i + primKeyAttr.length] = asOfKeyAttr[i].getFromAttribute();
-            }
-            return fullKey;
-        }
+       return ReladomoClassMetaData.fromFinder(finder).getUniqueExtractors();
     }
 
     public void loadFullCache()

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/transaction/TransactionOperation.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/transaction/TransactionOperation.java
@@ -26,6 +26,7 @@ import com.gs.fw.common.mithra.extractor.Extractor;
 import com.gs.fw.common.mithra.extractor.IdentityExtractor;
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import com.gs.fw.common.mithra.util.ListFactory;
+import com.gs.reladomo.metadata.ReladomoClassMetaData;
 
 import java.util.List;
 
@@ -264,7 +265,7 @@ public abstract class TransactionOperation
         UnderlyingObjectGetter getter = null;
         if (finder.getAsOfAttributes() != null)
         {
-            extractors = finder.getPrimaryKeyAttributes();
+            extractors = ReladomoClassMetaData.fromFinder(finder).getUniqueExtractors();
             getter = new TransactionalUnderlyingObjectGetter();
         }
         FullUniqueIndex index = new FullUniqueIndex(extractors, objects.size());

--- a/reladomo/src/main/java/com/gs/reladomo/metadata/ReladomoClassMetaData.java
+++ b/reladomo/src/main/java/com/gs/reladomo/metadata/ReladomoClassMetaData.java
@@ -25,6 +25,7 @@ import com.gs.fw.common.mithra.attribute.AsOfAttribute;
 import com.gs.fw.common.mithra.attribute.Attribute;
 import com.gs.fw.common.mithra.attribute.SourceAttributeType;
 import com.gs.fw.common.mithra.attribute.VersionAttribute;
+import com.gs.fw.common.mithra.extractor.Extractor;
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import com.gs.fw.common.mithra.list.DelegatingList;
 import com.gs.fw.common.mithra.util.ReflectionMethodCache;
@@ -466,6 +467,27 @@ public abstract class ReladomoClassMetaData
         {
             logger.error("Could not invoke method "+methodName+" on class "+classToInvoke, e);
             throw new MithraException("Could not invoke method "+methodName+" on class "+classToInvoke, e);
+        }
+    }
+
+    public Extractor[] getUniqueExtractors() {
+        if (relatedFinder.getAsOfAttributes() == null)
+        {
+            return relatedFinder.getPrimaryKeyAttributes();
+        }
+        else
+        {
+            Extractor[] primKeyAttr = relatedFinder.getPrimaryKeyAttributes();
+            AsOfAttribute[] asOfKeyAttr = relatedFinder.getAsOfAttributes();
+
+            Extractor[] fullKey = new Extractor[primKeyAttr.length + asOfKeyAttr.length];
+            System.arraycopy(primKeyAttr, 0, fullKey, 0, primKeyAttr.length);
+
+            for (int i = 0; i < asOfKeyAttr.length; i++)
+            {
+                fullKey[i + primKeyAttr.length] = asOfKeyAttr[i].getFromAttribute();
+            }
+            return fullKey;
         }
     }
 

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestDatedBitemporalNull.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestDatedBitemporalNull.java
@@ -45,7 +45,8 @@ public class  TestDatedBitemporalNull extends TestDatedBitemporal implements Tes
             BitemporalOrderNull.class,
             BitemporalOrderItemNull.class,
             BitemporalOrderStatusNull.class,
-            DatedAllTypesNull.class
+            DatedAllTypesNull.class,
+            ParaProduct.class
         };
     }
 


### PR DESCRIPTION
com.gs.fw.common.mithra.transaction.MultiUpdateOperation should check the 'fromAttributes' in addition to primary key attributes when combining updates on same objects so that the records for different dates do not interact with each other