### PR TITLE
Add jvm arg for timezone America/New_York. Fixes #28. 

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -291,6 +291,7 @@
                 <jvmarg value="-Dderby.storage.tempDirectory=${root}/reladomo/target/dbtemp/@{mithraxmlconfig}@{testclass}"/>
                 <jvmarg value="-Dderby.system.home=${root}/reladomo/target/dbtemp/@{mithraxmlconfig}@{testclass}"/>
                 <jvmarg value="-Dderby.system.durability=test"/>
+                <jvmarg value="-Duser.timezone=America/New_York"/>
                 <test name="@{testclass}" todir="${root}/reladomo/target/testresult"/>
             </junit>
             <replace casesensitive="true" dir="${root}/reladomo/target/testresult" includes="TEST-@{testclass}@{mithraxmlconfig}">
@@ -1867,6 +1868,7 @@
                 <jvmarg value="-Dderby.storage.tempDirectory=${root}/reladomo/target/dbtemp/@{mithraxmlconfig}@{testclass}"/>
                 <jvmarg value="-Dderby.system.home=${root}/reladomo/target/dbtemp/@{mithraxmlconfig}@{testclass}"/>
                 <jvmarg value="-Dderby.system.durability=test"/>
+                <jvmarg value="-Duser.timezone=America/New_York"/>
                 <test name="@{testclass}" todir="${root}/reladomoserial/target/testresult"/>
             </junit>
             <replace casesensitive="true" dir="${root}/reladomoserial/target/testresult" includes="TEST-@{testclass}@{mithraxmlconfig}">
@@ -2063,6 +2065,7 @@
                 <jvmarg value="-ea"/>
                 <jvmarg value="-Dlog4j.configuration=file:${root}/reladomo/src/test/resources/log4jWarn.config"/>
                 <jvmarg value="-Djacoco.args=${jacocovmarg}${root}/reladomoxa/target/coverage/@{mithraxmlconfig}@{testclass}@{heap}.exec"/>
+                <jvmarg value="-Duser.timezone=America/New_York"/>
                 <test name="@{testclass}" todir="${root}/reladomoxa/target/testresult"/>
             </junit>
             <replace casesensitive="true" dir="${root}/reladomoxa/target/testresult" includes="TEST-@{testclass}@{mithraxmlconfig}">

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/multivm/SlaveVm.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/multivm/SlaveVm.java
@@ -13,6 +13,7 @@
  specific language governing permissions and limitations
  under the License.
  */
+// Portions copyright Hiroshi Ito. Licensed under Apache 2.0 license
 
 package com.gs.fw.common.mithra.test.multivm;
 
@@ -143,6 +144,7 @@ public class SlaveVm
         cmdList.add(SYSTEM_CLASSPATH);
         cmdList.add("-server");
         cmdList.add("-XX:MaxPermSize=256m");
+        cmdList.add("-Duser.timezone=America/New_York");
         addProperties(cmdList);
         cmdList.add(this.getClass().getName());
         cmdList.add(""+port);


### PR DESCRIPTION
This fix addresses test failure issue in non-EST timezone in #28. 

In addition to adding jvm arg in `build.xml`, the same setting needed to be added to `SlaveVm.java` in order for multi vm test cases to run properly.

The fix was tested with `reladomo-test-suite` build in both JST and EST timezone in Mac OS.