### PR TITLE
Remove duplicated attribute "finalGetter" in type EmbeddedValueType. …

### DIFF
--- a/reladomogen/src/main/xsd/mithraobject.xsd
+++ b/reladomogen/src/main/xsd/mithraobject.xsd
@@ -342,12 +342,6 @@
                         any must be specified.
                     </xsd:documentation></xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="finalGetter" type="xsd:boolean" default="false">
-                    <xsd:annotation><xsd:documentation xml:lang="en">
-                        Generate a final method for this embedded value to prevent overriding. Default is false for
-                        backwards compatibility.
-                    </xsd:documentation></xsd:annotation>
-                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>


### PR DESCRIPTION
…The same attribute (name and target namespace) is already defined in type NestedEmbeddedValueType