### PR TITLE
Optimisticlockfail

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/ReladomoCorruptMilestoneException.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/ReladomoCorruptMilestoneException.java
@@ -1,0 +1,36 @@
+/*
+ Copyright 2016 Goldman Sachs.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+package com.gs.fw.common.mithra;
+
+
+
+/**
+ *  Exception for Unique Index Violation
+ */
+public class ReladomoCorruptMilestoneException extends MithraDatabaseException
+{
+
+    public ReladomoCorruptMilestoneException (String message)
+    {
+        super(message);
+    }
+
+    public ReladomoCorruptMilestoneException (String message, Throwable nestedException)
+    {
+        super(message, nestedException);
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraTestSuite.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraTestSuite.java
@@ -48,7 +48,6 @@ import junit.framework.TestSuite;
 public class MithraTestSuite
         extends TestSuite
 {
-
     public static Test suite()
     {
         String xmlFile = System.getProperty("mithra.xml.config");

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/SingleQueueExecutorTest.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/SingleQueueExecutorTest.java
@@ -16,11 +16,14 @@
 
 package com.gs.fw.common.mithra.test;
 
+import com.gs.fw.common.mithra.MithraManagerProvider;
+import com.gs.fw.common.mithra.MithraTransaction;
+import com.gs.fw.common.mithra.MithraUniqueIndexViolationException;
 import com.gs.fw.common.mithra.finder.Operation;
 import com.gs.fw.common.mithra.test.domain.*;
-import org.slf4j.Logger;
 import com.gs.fw.common.mithra.util.ExecutorErrorHandler;
 import com.gs.fw.common.mithra.util.SingleQueueExecutor;
+import org.slf4j.Logger;
 
 import java.sql.Timestamp;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -34,10 +37,11 @@ public class SingleQueueExecutorTest extends MithraTestAbstract
     public Class[] getRestrictedClassList()
     {
         return new Class[]
-        {
-            ParaBalance.class,
-            ParaPosition.class,
-        };
+                {
+                        ParaBalance.class,
+                        ParaPosition.class,
+                        TinyBalance.class
+                };
     }
 
     public void testSingleQueueExecutorSingleThread() throws Exception
@@ -49,9 +53,9 @@ public class SingleQueueExecutorTest extends MithraTestAbstract
         executor.setUseBulkInsert();
 
         Operation op = ParaPositionFinder.productIdentifier().eq("TSWAP:1000000001").
-                       and(ParaPositionFinder.accountNumber().eq("76095661")).
-                       and(ParaPositionFinder.accountSubtype().eq("01")).
-                       and(ParaPositionFinder.businessDate().eq(businessDate));
+                and(ParaPositionFinder.accountNumber().eq("76095661")).
+                and(ParaPositionFinder.accountSubtype().eq("01")).
+                and(ParaPositionFinder.businessDate().eq(businessDate));
         ParaPosition paraPositionDB = ParaPositionFinder.findOne(op);
 
         ParaPosition paraPosition = new ParaPosition(InfinityTimestamp.getParaInfinity());
@@ -71,6 +75,59 @@ public class SingleQueueExecutorTest extends MithraTestAbstract
 
         executor.addForUpdate(paraPositionDB,paraPosition);
         executor.waitUntilFinished();
+    }
+
+    public void testWithCorruptedOptimisticLock() throws Exception
+    {
+        Timestamp businessDate = new Timestamp(timestampFormat.parse("2004-08-27 23:59:00.0").getTime());
+
+
+        MithraTransaction tx = MithraManagerProvider.getMithraManager().startOrContinueTransaction();
+        TinyBalance bal = new TinyBalance(businessDate);
+        bal.setAcmapCode ("B");
+        bal.setBalanceId (8866);
+        bal.setQuantity (30);
+        bal.setBusinessDateFrom (Timestamp.valueOf("2004-08-25 23:59:00.0"));
+        bal.setBusinessDateTo (Timestamp.valueOf("2004-08-28 23:59:00.0"));
+        bal.insert ();
+        tx.commit ();
+
+        tx = MithraManagerProvider.getMithraManager().startOrContinueTransaction();
+        bal = new TinyBalance(businessDate);
+        bal.setAcmapCode ("B");
+        bal.setBalanceId (8866);
+        bal.setQuantity (700);
+        bal.setBusinessDateFrom (Timestamp.valueOf("2004-08-16 23:59:00.0"));
+        bal.setBusinessDateTo (Timestamp.valueOf("2004-10-13 23:59:00.0"));
+        bal.insert ();
+        tx.commit ();
+
+
+        Operation op = TinyBalanceFinder.acmapCode ().eq("B").and(TinyBalanceFinder.balanceId ().eq(8866)).
+                and(TinyBalanceFinder.businessDate().eq(businessDate));
+        TinyBalance tinyBalanceDB = TinyBalanceFinder.findOne(op);
+
+        SingleQueueExecutor executor = new SingleQueueExecutor(1, TinyBalanceFinder.balanceId ().ascendingOrderBy(), 10,
+                TinyBalanceFinder.getFinderInstance(), 0);
+
+        executor.setUseBulkInsert();
+
+        op = TinyBalanceFinder.acmapCode ().eq("B").and(TinyBalanceFinder.balanceId ().eq(8866)).
+                and(TinyBalanceFinder.businessDate().eq(businessDate));
+        tinyBalanceDB = TinyBalanceFinder.findOne(op);
+
+        TinyBalance tinyBalance = new TinyBalance(InfinityTimestamp.getParaInfinity());
+
+        executor.addForUpdate(tinyBalanceDB, tinyBalance);
+        try
+        {
+            executor.waitUntilFinished ();
+            fail("exception expected");
+        } catch (Exception e)
+        {
+            assertTrue(e.getMessage (), e.getMessage().contains("2004-08-25 23:59:00.0") && e.getMessage().contains("2004-08-16 23:59:00.0"));
+        }
+
     }
 
     public void testSingleQueueExecutorErrorHandler()

--- a/reladomogen/src/main/java/com/gs/fw/common/mithra/generator/RelationshipAttribute.java
+++ b/reladomogen/src/main/java/com/gs/fw/common/mithra/generator/RelationshipAttribute.java
@@ -737,6 +737,10 @@ public class RelationshipAttribute implements CommonAttribute
 
     public boolean dependsOnlyOnFromToObjects()
     {
+        if (this.parsedQuery == null)
+        {
+            return false;
+        }
         HashSet set = new HashSet();
         this.parsedQuery.addDependentClassesToSet(set);
         return set.size() <= 1;


### PR DESCRIPTION
Let's say there are multiple duplicate records with an overlapping milestone in the database. When the SingleQueueExecution attempted to update such records it seems to have only one record in memory and the update operation threw OptimisticLockException since two records updated in the database. The exception caused the SingleQueueExecution to get into the infinite loop because it kept pushing the batch into the end of the queue.

To fix this the optimistic update/delete failures are differentiated. Cases, where multiple rows were updates treated differently and MithraUniqueIndexViolationException, is throws without retry.
