### PR TITLE
TXRollback

### DIFF
--- a/reladomo/src/test-util/java/com/gs/fw/common/mithra/test/MithraTestResource.java
+++ b/reladomo/src/test-util/java/com/gs/fw/common/mithra/test/MithraTestResource.java
@@ -564,7 +564,7 @@ public class MithraTestResource
         MithraManager mithra = MithraManagerProvider.getMithraManager();
         try
         {
-            if (mithra.isInTransaction())
+            while (mithra.isInTransaction())
             {
                 logger.error("incomplete transaction. attempting rollback");
                 mithra.getCurrentTransaction().rollback();

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/SingleQueueExecutorTest.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/SingleQueueExecutorTest.java
@@ -16,6 +16,8 @@
 
 package com.gs.fw.common.mithra.test;
 
+import com.gs.fw.common.mithra.MithraManagerProvider;
+import com.gs.fw.common.mithra.MithraTransaction;
 import com.gs.fw.common.mithra.finder.Operation;
 import com.gs.fw.common.mithra.test.domain.*;
 import org.slf4j.Logger;


### PR DESCRIPTION
The teardown was only rolling back the current transaction. The test with multiple transactions did not release all resources and the subsequent tests failed.