### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/build/pom-templates/pom-reladomo-test-util.xml
+++ b/build/pom-templates/pom-reladomo-test-util.xml
@@ -26,7 +26,7 @@
     <packaging>bundle</packaging>
 
     <name>Reladomo Test Utilities</name>
-    <description>Reladomo test utilities faciliate writing tests for projects using Reladomo.</description>
+    <description>Reladomo test utilities facilitate writing tests for projects using Reladomo.</description>
     <url>https://github.com/goldmansachs/reladomo</url>
 
     <licenses>

--- a/libboot/src/main/java/org/libboot/Libboot.java
+++ b/libboot/src/main/java/org/libboot/Libboot.java
@@ -42,7 +42,7 @@ public class Libboot
     private static final int NEEDS_REDOWNLOAD = 200;
     private static final int ERROR_WRONG_ARGS = -1;
     private static final int ERROR_DOWNLOAD_FAILED = -2;
-    private static final int ERROR_UNKOWN = -4;
+    private static final int ERROR_UNKNOWN = -4;
     private static final int NO_ERROR = 0;
 
     public static void main(String[] args)
@@ -183,7 +183,7 @@ public class Libboot
             catch (Throwable e)
             {
                 error("Unrecoverable error "+printableError(e));
-                return ERROR_UNKOWN;
+                return ERROR_UNKNOWN;
             }
             finally
             {

--- a/reladomo/src/doc/docbook/mithraTestResource/ReladomoTestResource.xml
+++ b/reladomo/src/doc/docbook/mithraTestResource/ReladomoTestResource.xml
@@ -77,7 +77,7 @@ this.mithraTestResource.setUp();
     <sect2>
         <title>Reladomo runtime configuration for tests</title>
         <para>
-            The runtime configuration is used by the MithraTestReosurce to create the neccesary table in the in memory database used for tests.
+            The runtime configuration is used by the MithraTestReosurce to create the necessary table in the in memory database used for tests.
             Also, the MithraTestResource initializes Reladomo using that runtime configuration. It is required that a "resourceName" property is
             defined.
             <programlisting language="xml"><![CDATA[

--- a/reladomo/src/doc/docbook/mithraddl/ReladomoDdlGenerator.xml
+++ b/reladomo/src/doc/docbook/mithraddl/ReladomoDdlGenerator.xml
@@ -79,7 +79,7 @@
             </para>
 
             <para>
-            The database type must be specified using the <code>databaseType</code> element. Acceptible values
+            The database type must be specified using the <code>databaseType</code> element. Acceptable values
             for the type are &quot;sybase&quot; and &quot;udb82&quot;.
             </para>
 

--- a/reladomo/src/doc/docbook/presentations/reladomoInternalCacheStructure/ReladomoInternalCacheStructure.xml
+++ b/reladomo/src/doc/docbook/presentations/reladomoInternalCacheStructure/ReladomoInternalCacheStructure.xml
@@ -344,7 +344,7 @@
                     <para>By default it's a partial cache and no configuration is required</para>
                 </listitem>
                 <listitem>
-                    <para>The default can be overriden in the runtime configuration</para>
+                    <para>The default can be overridden in the runtime configuration</para>
                 </listitem>
                 <listitem>
                     <para>The client tries to answer queries from its cache first before hitting the middle tier</para>

--- a/reladomo/src/main/grammar/mithra.jjt
+++ b/reladomo/src/main/grammar/mithra.jjt
@@ -1,5 +1,5 @@
 /**
- * This grammer files is used to generate the parser for Mithra relationship queries. The code generated is checked into
+ * This grammar files is used to generate the parser for Mithra relationship queries. The code generated is checked into
  * cvs in package com.gs.fw.common.mithra.generator.queryparser. Care should be taken when regenerating code because we have
  * custom code in SimpleNode, ASTLiteral, and ASTAttributeName
  *    

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/MithraManager.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/MithraManager.java
@@ -645,7 +645,7 @@ public class MithraManager
 
     /**
      * sets the value of minimum queries to keep per class. 32 is the default. This can be
-     * overriden in a configuration file using &lt;MithraRuntime defaultMinQueriesToKeep="100"&gt;
+     * overridden in a configuration file using &lt;MithraRuntime defaultMinQueriesToKeep="100"&gt;
      * or on a per object basis
      * &lt;MithraObjectConfiguration className="com.gs.fw.para.domain.desk.product.ProductScrpMap" cacheType="partial" minQueriesToKeep="100"/&gt;
      * @param defaultMinQueriesToKeep
@@ -657,7 +657,7 @@ public class MithraManager
 
     /**
      * sets the value of relationship cache per class. 10000 is the default. This can be
-     * overriden in a configuration file using &lt;MithraRuntime defaultRelationshipCacheSize="100"&gt;
+     * overridden in a configuration file using &lt;MithraRuntime defaultRelationshipCacheSize="100"&gt;
      * or on a per object basis
      * &lt;MithraObjectConfiguration className="com.gs.fw.para.domain.desk.product.ProductScrpMap" cacheType="partial" relationshipCacheSize="50000"/&gt;
      * @param defaultRelationshipCacheSize

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java
@@ -522,7 +522,7 @@ public abstract class AbstractNonDatedCache extends AbstractCache
 
     public void reindexForTransaction(MithraObject object, AttributeUpdateWrapper updateWrapper)
     {
-        throw new RuntimeException("not implemented. expected to be overriden by transactional cache.");
+        throw new RuntimeException("not implemented. expected to be overridden by transactional cache.");
     }
 
     public void removeIgnoringTransaction(MithraObject object)
@@ -532,27 +532,27 @@ public abstract class AbstractNonDatedCache extends AbstractCache
 
     public Object preparePut(MithraObject obj)
     {
-        throw new RuntimeException("not implemented. expected to be overriden by transactional cache.");
+        throw new RuntimeException("not implemented. expected to be overridden by transactional cache.");
     }
 
     public void commitPreparedForIndex(Object index)
     {
-        throw new RuntimeException("not implemented. expected to be overriden by transactional cache.");
+        throw new RuntimeException("not implemented. expected to be overridden by transactional cache.");
     }
 
     public void commitRemovedObject(MithraDataObject data)
     {
-        throw new RuntimeException("not implemented. expected to be overriden by transactional cache.");
+        throw new RuntimeException("not implemented. expected to be overridden by transactional cache.");
     }
 
     public void commitObject(MithraTransactionalObject mithraObject, MithraDataObject oldData)
     {
-        throw new RuntimeException("not implemented. expected to be overriden by transactional cache.");
+        throw new RuntimeException("not implemented. expected to be overridden by transactional cache.");
     }
 
     public Object getObjectByPrimaryKey(MithraDataObject data, boolean evenIfDirty)
     {
-        throw new RuntimeException("not implemented. expected to be overriden by transactional cache.");
+        throw new RuntimeException("not implemented. expected to be overridden by transactional cache.");
     }
 
     public boolean enrollDatedObject(MithraDatedTransactionalObject mithraObject, DatedTransactionalState prevState, boolean forWrite)

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/cache/offheap/FastUnsafeOffHeapDataStorage.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/cache/offheap/FastUnsafeOffHeapDataStorage.java
@@ -981,7 +981,7 @@ public class FastUnsafeOffHeapDataStorage implements OffHeapDataStorage
         {
             UNSAFE.freeMemory(this.baseAddress);
             destroyed = true;
-            this.baseAddress = -(1L << 40); // about a terrabyte
+            this.baseAddress = -(1L << 40); // about a terabyte
             this.dataArray = null;
             this.pageVersionList.destroy();
         }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/cache/offheap/FastUnsafeOffHeapIntArrayStorage.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/cache/offheap/FastUnsafeOffHeapIntArrayStorage.java
@@ -319,7 +319,7 @@ public class FastUnsafeOffHeapIntArrayStorage implements OffHeapIntArrayStorage
         {
             destroyed = true;
             UNSAFE.freeMemory(this.baseAddress);
-            this.baseAddress = -(1L << 40); // about a terrabyte
+            this.baseAddress = -(1L << 40); // about a terabyte
         }
     }
 

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/cacheloader/DependentLoaderFactoryImpl.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/cacheloader/DependentLoaderFactoryImpl.java
@@ -368,13 +368,13 @@ public class DependentLoaderFactoryImpl implements DependentLoaderFactory
         {
             if (each.isAsOfAttribute())
             {
-                throw new RuntimeException("CacheLoader cannnot handle AsOfOperation filter (" + op + ") on the dependent relationship " + this.relationship +
+                throw new RuntimeException("CacheLoader cannot handle AsOfOperation filter (" + op + ") on the dependent relationship " + this.relationship +
                         " all Milestoning logic has to be implemented in the cache loader factory classes (i.e. PmeYtdBalanceTopLevelLoaderFactory). " +
                         "Consider creating cacheLoader-specific relationship without AsOfAttribute filtering and with specialized factory in the cacheLoader.xml.");
             }
             if (each.isSourceAttribute())
             {
-                throw new RuntimeException("CacheLoader cannnot handle Source attribute filter (" + op + ") on the dependent relationship " + this.relationship +
+                throw new RuntimeException("CacheLoader cannot handle Source attribute filter (" + op + ") on the dependent relationship " + this.relationship +
                         " the source attributes have to be explicitly set in the cacheLoader.xml sourceAttributes properties. " +
                         "Consider creating cacheLoader-specific relationship without source attribute filtering and with source attribute defined in the cacheLoader.xml.");
             }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/AbstractConnectionManager.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/AbstractConnectionManager.java
@@ -342,7 +342,7 @@ public abstract class AbstractConnectionManager
     }
 
     /**
-     * sets the intial size of the pool. These connections will be established when initalizePool() is called.
+     * sets the initial size of the pool. These connections will be established when initalizePool() is called.
      * @param initialSize
      */
     public void setInitialSize(int initialSize)

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionPoolingDataSource.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionPoolingDataSource.java
@@ -319,7 +319,7 @@ public class XAConnectionPoolingDataSource implements DataSource
         private List availableConnections = new ArrayList();
         private List connectionsInUse = new ArrayList();
 
-        private boolean commited;
+        private boolean committed;
         private boolean rolledback = false;
         private final MithraTransaction ownerTransaction;
 
@@ -440,7 +440,7 @@ public class XAConnectionPoolingDataSource implements DataSource
 
         public void rollback(Xid xid) throws XAException
         {
-            if(commited)
+            if(committed)
             {
                 throw new XAException("Transaction is already committed");
             }
@@ -492,7 +492,7 @@ public class XAConnectionPoolingDataSource implements DataSource
 
         public void commit(Xid xid, boolean b) throws XAException
         {
-            if(commited)
+            if(committed)
             {
                 throw new XAException("Transaction is already committed");
             }
@@ -503,7 +503,7 @@ public class XAConnectionPoolingDataSource implements DataSource
                     throw new XAException("Detected open jdbc connections. Change code to close all connection borrowed from the connection manager");
                 }
                 commitConnections(availableConnections);
-                commited = true;
+                committed = true;
             }
             catch (SQLException e)
             {

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraCodeGeneratedDatabaseObject.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraCodeGeneratedDatabaseObject.java
@@ -36,7 +36,7 @@ import java.util.TimeZone;
 
 public interface MithraCodeGeneratedDatabaseObject
 {
-    // retreive source attribute
+    // retrieve source attribute
     public Object getSourceAttributeValueForSelectedObjectGeneric(SqlQuery query, int queryNumber);
 
     public Object getSourceAttributeValueGeneric(SqlQuery query, MapperStackImpl mapperStack, int sourceNumber);

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java
@@ -36,11 +36,11 @@ public class Udb82DatabaseType extends AbstractDatabaseType
     private static final String DEADLOCK_OR_TIMEOUT2 = "40001";
     private static final int DEADLOCK_OR_TIMEOUT_ERROR_CODE = -911;
     private static final int DISCONNECT_ERROR_CODE = -4499;
-    private static final int CONNECTION_NON_EXISTANT_ERROR_CODE = -1024;
+    private static final int CONNECTION_NON_EXISTENT_ERROR_CODE = -1024;
     private static final int DUPLICATE_INSERT_UPDATE = -803;
-    private static final int CONNECTION_NON_EXISTANT_ERROR_CODE2 = -900;
-    private static final int CONNECTION_NON_EXISTANT_ERROR_CODE3 = -4470;
-    private static final int CONNECTION_NON_EXISTANT_ERROR_CODE4 = -1224;
+    private static final int CONNECTION_NON_EXISTENT_ERROR_CODE2 = -900;
+    private static final int CONNECTION_NON_EXISTENT_ERROR_CODE3 = -4470;
+    private static final int CONNECTION_NON_EXISTENT_ERROR_CODE4 = -1224;
 //    private static final String DEADLOCK_REASON_CODE = "00C90088";
     private static final String TIMEOUT_REASON_CODE = "00C9008E";
     private static final String READ_ONLY = " FOR READ ONLY";
@@ -364,10 +364,10 @@ public class Udb82DatabaseType extends AbstractDatabaseType
     @Override
     public boolean isConnectionDeadWithoutRecursion(SQLException e)
     {
-        return (e.getErrorCode() == CONNECTION_NON_EXISTANT_ERROR_CODE  ||
-                e.getErrorCode() == CONNECTION_NON_EXISTANT_ERROR_CODE2 ||
-                e.getErrorCode() == CONNECTION_NON_EXISTANT_ERROR_CODE3 ||
-                e.getErrorCode() == CONNECTION_NON_EXISTANT_ERROR_CODE4 ||
+        return (e.getErrorCode() == CONNECTION_NON_EXISTENT_ERROR_CODE  ||
+                e.getErrorCode() == CONNECTION_NON_EXISTENT_ERROR_CODE2 ||
+                e.getErrorCode() == CONNECTION_NON_EXISTENT_ERROR_CODE3 ||
+                e.getErrorCode() == CONNECTION_NON_EXISTENT_ERROR_CODE4 ||
                 e.getErrorCode() == DISCONNECT_ERROR_CODE);
     }
 

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/AsOfEqualityChecker.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/AsOfEqualityChecker.java
@@ -445,7 +445,7 @@ public class AsOfEqualityChecker implements MapperStack
         if (asOfAttributes != null)
         {
             initRegisteredAsOfAttributesWithMapperStack();
-            //todo: pop to container boundry
+            //todo: pop to container boundary
             ObjectWithMapperStack<TemporalAttribute> tempObject = getOrCreateTemp();
             MapperStackImpl atBoundary = this.mapperStackImpl.ifAtContainerBoundaryCloneAndPop();
             for(int i=0;i<asOfAttributes.length;i++)

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/SqlParameterSetter.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/SqlParameterSetter.java
@@ -25,7 +25,7 @@ public interface SqlParameterSetter
 {
 
     /**
-     * set the parameters on the statment and return the number of parameters set
+     * set the parameters on the statement and return the number of parameters set
      *
      * @param pstmt statement
      * @param startIndex index to start setting parameters

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/list/AdhocDetachedList.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/list/AdhocDetachedList.java
@@ -171,7 +171,7 @@ public class AdhocDetachedList extends TransactionalAdhocFastList
         this.addRemovedItem((MithraTransactionalObject) obj);
     }
 
-// remove(Object) is not overriden because FastList implementation calls remove(int)
+// remove(Object) is not overridden because FastList implementation calls remove(int)
 //    public boolean remove(Object object)
 
     public void clear()

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/remote/RemoteMithraServiceImpl.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/remote/RemoteMithraServiceImpl.java
@@ -95,7 +95,7 @@ public class RemoteMithraServiceImpl implements RemoteMithraService
                 }
                 if (workerTask == null || workerTask.isTimedOut())
                 {
-                    throw new MithraTransactionException("server side transaction context is timed out or non-existant");
+                    throw new MithraTransactionException("server side transaction context is timed out or non-existent");
                 }
             }
             return workerTask;
@@ -153,7 +153,7 @@ public class RemoteMithraServiceImpl implements RemoteMithraService
         }
         if (workerTask == null || workerTask.isTimedOut())
         {
-            throw new MithraTransactionException("server side transaction context is timed out or non-existant");
+            throw new MithraTransactionException("server side transaction context is timed out or non-existent");
         }
         workerTask.getRemoteTransactionId().setRequestorVmId(remoteTransactionId.getRequestorVmId());
         workerTask.commit(onePhase);
@@ -169,7 +169,7 @@ public class RemoteMithraServiceImpl implements RemoteMithraService
         }
         if (workerTask == null || workerTask.isTimedOut())
         {
-            throw new MithraTransactionException("server side transaction context is timed out or non-existant");
+            throw new MithraTransactionException("server side transaction context is timed out or non-existent");
         }
         workerTask.rollback();
         logger.debug("server side rollback finished");
@@ -450,7 +450,7 @@ public class RemoteMithraServiceImpl implements RemoteMithraService
         }
         if (workerTask == null || workerTask.isTimedOut())
         {
-            throw new MithraTransactionException("server side transaction context is timed out or non-existant");
+            throw new MithraTransactionException("server side transaction context is timed out or non-existent");
         }
         workerTask.waitForOtherTransactionToFinish();
         logger.debug("server side rollback finished");

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/transaction/MithraRootTransaction.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/transaction/MithraRootTransaction.java
@@ -786,7 +786,7 @@ public class MithraRootTransaction extends MithraLocalTransaction implements Syn
     {
         this.asyncRollback = true;
         super.asyncRollback();
-        // this is a desparate attempt at rolling back, so handle as much of the errors as possible
+        // this is a desperate attempt at rolling back, so handle as much of the errors as possible
         for (Iterator iterator = this.enlistedResources.iterator(); iterator.hasNext();)
         {
             XAResource xaResource = (XAResource) iterator.next();
@@ -927,7 +927,7 @@ public class MithraRootTransaction extends MithraLocalTransaction implements Syn
     {
         if (this.txStatus == MITHRA_STATUS_COMMITTED)
         {
-            throw new MithraTransactionException("cannot rollback commited transaction.");
+            throw new MithraTransactionException("cannot rollback committed transaction.");
         }
 
         this.expectRollback = true;

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/util/MithraConfigurationManager.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/util/MithraConfigurationManager.java
@@ -100,7 +100,7 @@ public class MithraConfigurationManager
 
     /**
      * sets the value of minimum queries to keep per class. 32 is the default. This can be
-     * overriden in a configuration file using &lt;MithraRuntime defaultMinQueriesToKeep="100"&gt;
+     * overridden in a configuration file using &lt;MithraRuntime defaultMinQueriesToKeep="100"&gt;
      * or on a per object basis
      * &lt;MithraObjectConfiguration className="com.gs.fw.para.domain.desk.product.ProductScrpMap" cacheType="partial" minQueriesToKeep="100"/&gt;
      * @param defaultMinQueriesToKeep the default minimum queries to keep
@@ -112,7 +112,7 @@ public class MithraConfigurationManager
 
     /**
      * sets the value of relationship cache per class. 10000 is the default. This can be
-     * overriden in a configuration file using &lt;MithraRuntime defaultRelationshipCacheSize="100"&gt;
+     * overridden in a configuration file using &lt;MithraRuntime defaultRelationshipCacheSize="100"&gt;
      * or on a per object basis
      * &lt;MithraObjectConfiguration className="com.gs.fw.para.domain.desk.product.ProductScrpMap" cacheType="partial" relationshipCacheSize="50000"/&gt;
      * @param defaultRelationshipCacheSize the default cache size to set

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/util/MultiQueueExecutor.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/util/MultiQueueExecutor.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * the first column in the unique database index be used for hashing. All Mithra object attributes can be used
  * for hashing.
  *
- * This class is not synchronized. It expects to be called from a single thread or be extrenally synchronized.
+ * This class is not synchronized. It expects to be called from a single thread or be externally synchronized.
  *
  * The typical usage of this class is as follows:
  *

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/util/SingleQueueExecutor.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/util/SingleQueueExecutor.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * the first column in the unique database index be used for hashing. All Mithra object attributes can be used
  * for hashing.
  *
- * This class is not synchronized. It expects to be called from a single thread or be extrenally synchronized.
+ * This class is not synchronized. It expects to be called from a single thread or be externally synchronized.
  *
  * The typical usage of this class is as follows:
  *

--- a/reladomo/src/main/java/com/gs/reladomo/util/Base64.java
+++ b/reladomo/src/main/java/com/gs/reladomo/util/Base64.java
@@ -385,7 +385,7 @@ public class Base64
      * anywhere along their length by specifying
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 3 for
+     * are large enough to accommodate <var>srcOffset</var> + 3 for
      * the <var>source</var> array or <var>destOffset</var> + 4 for
      * the <var>destination</var> array.
      * The actual number of significant bytes in your array is
@@ -916,7 +916,7 @@ public class Base64
      * anywhere along their length by specifying
      * <var>srcOffset</var> and <var>destOffset</var>.
      * This method does not check to make sure your arrays
-     * are large enough to accomodate <var>srcOffset</var> + 4 for
+     * are large enough to accommodate <var>srcOffset</var> + 4 for
      * the <var>source</var> array or <var>destOffset</var> + 3 for
      * the <var>destination</var> array.
      * This method returns the actual number of bytes that

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBasicRetrieval.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBasicRetrieval.java
@@ -306,7 +306,7 @@ public class TestBasicRetrieval
         }
         if (!user.isActive())
         {
-            fail("improper inflation of nullable primitive attribute when default is provided. Default value is not availble");
+            fail("improper inflation of nullable primitive attribute when default is provided. Default value is not available");
         }
         try
         {

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBigDecimal.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBigDecimal.java
@@ -500,7 +500,7 @@ public class TestBigDecimal extends MithraTestAbstract
         }
         catch (MithraBusinessException e)
         {
-            logger.info("Expected excpetion: ", e);
+            logger.info("Expected exception: ", e);
         }
 
         try
@@ -513,7 +513,7 @@ public class TestBigDecimal extends MithraTestAbstract
         }
         catch (MithraBusinessException e)
         {
-            logger.info("Expected excpetion: ", e);
+            logger.info("Expected exception: ", e);
         }
     }
 

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTempObject.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTempObject.java
@@ -669,8 +669,8 @@ public class TestTempObject extends MithraTestAbstract
     {
         TemporaryContext temporaryContextA = null;
         TemporaryContext temporaryContextB = null;
-        Throwable destoryExceptionA = null;
-        Throwable destoryExceptionB = null;
+        Throwable destroyExceptionA = null;
+        Throwable destroyExceptionB = null;
         try
         {
             temporaryContextA = PositionDriverFinder.createTemporaryContext("A");
@@ -717,8 +717,8 @@ public class TestTempObject extends MithraTestAbstract
                 catch (Throwable e)
                 {
                     // we have to do this so we don't lose the exeption in the main part of the test
-                    getLogger().error("destory temp context failed", e);
-                    destoryExceptionA = e;
+                    getLogger().error("destroy temp context failed", e);
+                    destroyExceptionA = e;
                 }
             }
             if (temporaryContextB != null)
@@ -729,14 +729,14 @@ public class TestTempObject extends MithraTestAbstract
                 }
                 catch (Throwable e)
                 {
-                    getLogger().error("destory temp context failed", e);
-                    destoryExceptionB = e;
+                    getLogger().error("destroy temp context failed", e);
+                    destroyExceptionB = e;
                 }
             }
         }
         // if we get here, there wasn't another exception above.
-        if (destoryExceptionA != null) fail("destory failed");
-        if (destoryExceptionB != null) fail("destory failed");
+        if (destroyExceptionA != null) fail("destroy failed");
+        if (destroyExceptionB != null) fail("destroy failed");
     }
 
     private void createPositionDriverA()

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTransactionalObject.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTransactionalObject.java
@@ -2829,7 +2829,7 @@ private static class TransactionalResourceForTests implements Synchronization
         this.currentTx = null;
         if (status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING)
         {
-            //Load the commited map with the transactional map
+            //Load the committed map with the transactional map
             this.commitedMap.putAll(this.transactionalMap);
             this.transactionalMap.clear();
         }

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/aggregate/TestAggregationWithHavingClause.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/aggregate/TestAggregationWithHavingClause.java
@@ -1375,7 +1375,7 @@ public class TestAggregationWithHavingClause extends MithraTestAbstract
     }
 
 
-    // We still need to undertsand how to do this case. In this case we are going from Order to Items,we are aggregating
+    // We still need to understand how to do this case. In this case we are going from Order to Items,we are aggregating
     // Order but the having operation is aggregating on items
     public void xtestDatedHavingEqUsingDifferentMappedAttributeInHaving()
     {

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/cacheloader/DependentLoaderFactoryTest.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/cacheloader/DependentLoaderFactoryTest.java
@@ -231,7 +231,7 @@ public class DependentLoaderFactoryTest extends TestCase
         }
         catch (RuntimeException e)
         {
-            assertTrue(e.getMessage().contains("cannnot handle"));
+            assertTrue(e.getMessage().contains("cannot handle"));
         }
     }
 

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/tinyproxy/EchoImpl.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/tinyproxy/EchoImpl.java
@@ -90,7 +90,7 @@ public class EchoImpl implements Echo
         /**
          * Mapping of primitive wrapper classes to primitive types
          */
-        private static final ImmutableMap<Class<?>, Class<?>> WRAPPER_TO_PRIMATIVES = ((UnsortedMapIterable<Class<?>, Class<?>>)UnifiedMap.<Class<?>, Class<?>>newMap()
+        private static final ImmutableMap<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVES = ((UnsortedMapIterable<Class<?>, Class<?>>)UnifiedMap.<Class<?>, Class<?>>newMap()
                 .withKeyValue(Short.class, short.class)
                 .withKeyValue(Boolean.class, boolean.class)
                 .withKeyValue(Byte.class, byte.class)
@@ -101,7 +101,7 @@ public class EchoImpl implements Echo
                 .withKeyValue(Double.class, double.class))
                 .toImmutable();
 
-        private static final ImmutableMap<Class<?>, Class<?>> PRIMITIVES_TO_WRAPPERS = ((UnsortedMapIterable<Class<?>, Class<?>>)MapIterate.reverseMapping(WRAPPER_TO_PRIMATIVES.castToMap())).toImmutable();
+        private static final ImmutableMap<Class<?>, Class<?>> PRIMITIVES_TO_WRAPPERS = ((UnsortedMapIterable<Class<?>, Class<?>>)MapIterate.reverseMapping(WRAPPER_TO_PRIMITIVES.castToMap())).toImmutable();
 
         private ReflectionHelper()
         {

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/util/tinyproxy/StreamBasedInvocator.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/util/tinyproxy/StreamBasedInvocator.java
@@ -112,7 +112,7 @@ public class StreamBasedInvocator
                     {
                         e = ((InvocationTargetException) e).getTargetException();
                     }
-                    LOGGER.error("an exception occured while invoking {}", method.getName(), e);
+                    LOGGER.error("an exception occurred while invoking {}", method.getName(), e);
                     context.setReturnValue(e, true);
 
                 }

--- a/reladomo/src/test/reladomo-xml/Filing.xml
+++ b/reladomo/src/test/reladomo-xml/Filing.xml
@@ -81,7 +81,7 @@
     <Attribute name="changedBy" javaType="String" columnName="CHANGED_BY" nullable="false"/>
     <Attribute name="statusId" javaType="int" columnName="STATUS_ID"/>
     <Attribute name="payingEntityId" javaType="long" columnName="PAYING_ENTITY_ID"/>
-    <Attribute name="attahcmentRecieved" javaType="String" columnName="ATTACHMENT_RECIEVED"/>
+    <Attribute name="attahcmentRecieved" javaType="String" columnName="ATTACHMENT_RECEIVED"/>
     <Attribute name="totalLiabilityAtExtension" javaType="double" columnName="LIABILITY_AT_EXT_AMT"/>
     <Attribute name="estimatedPaymentAmountIncome" javaType="double" columnName="EST_PAYMT_INC_AMT"/>
     <Attribute name="estimatedPaymentAmountNonIncome" javaType="double" columnName="EST_PAYMT_NON_INC_AMT"/>

--- a/reladomogen/src/main/java/com/gs/fw/common/mithra/generator/MithraObjectTypeWrapper.java
+++ b/reladomogen/src/main/java/com/gs/fw/common/mithra/generator/MithraObjectTypeWrapper.java
@@ -1692,7 +1692,7 @@ public class MithraObjectTypeWrapper extends MithraBaseObjectTypeWrapper
             }
             if (this.getSourceAttribute() != null && this.getSuperClassWrapper().getSourceAttribute() != null)
             {
-                errorMessages.add("source attributes are not allowed to be overriden in "+
+                errorMessages.add("source attributes are not allowed to be overridden in "+
                         this.getClassName()+"."+this.getSourceAttribute().getName()+" overriding "+
                         this.getSuperClassWrapper().getClassName()+"."+this.getSuperClassWrapper().getSourceAttribute().getName());
             }

--- a/reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java
+++ b/reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java
@@ -24,7 +24,7 @@ public class TokenMgrError extends Error
     */
 
    /**
-    * Lexical error occured.
+    * Lexical error occurred.
     */
    static final int LEXICAL_ERROR = 0;
 
@@ -103,10 +103,10 @@ public class TokenMgrError extends Error
     * token manager to indicate a lexical error.
     * Parameters : 
     *    EOFSeen     : indicates if EOF caused the lexicl error
-    *    curLexState : lexical state in which this error occured
-    *    errorLine   : line number when the error occured
-    *    errorColumn : column number when the error occured
-    *    errorAfter  : prefix that was seen before this error occured
+    *    curLexState : lexical state in which this error occurred
+    *    errorLine   : line number when the error occurred
+    *    errorColumn : column number when the error occurred
+    *    errorAfter  : prefix that was seen before this error occurred
     *    curchar     : the offending character
     * Note: You can customize the lexical error message by modifying this method.
     */

--- a/reladomogen/src/main/xsd/mithraobject.xsd
+++ b/reladomogen/src/main/xsd/mithraobject.xsd
@@ -745,7 +745,7 @@
                 <xsd:annotation><xsd:documentation xml:lang="en">
                     "auto" - Automatically determine if the relationship qualifies for a foreign key. If one side
                     of the relationship has a "to-one" cardinality and it's not a dated object,
-                    the code will assume there is a foregin key.
+                    the code will assume there is a foreign key.
                 </xsd:documentation></xsd:annotation>
             </xsd:enumeration>
             <xsd:enumeration value="false">

--- a/samples/reladomo-sample-simple/src/main/resources/reladomo/models/reladomoobject.xsd
+++ b/samples/reladomo-sample-simple/src/main/resources/reladomo/models/reladomoobject.xsd
@@ -830,7 +830,7 @@
                 <xsd:annotation><xsd:documentation xml:lang="en">
                     "auto" - Automatically determine if the relationship qualifies for a foreign key. If one side
                     of the relationship has a "to-one" cardinality and it's not a dated object,
-                    the code will assume there is a foregin key.
+                    the code will assume there is a foreign key.
                 </xsd:documentation></xsd:annotation>
             </xsd:enumeration>
             <xsd:enumeration value="false">


### PR DESCRIPTION
This pull request fixes the typos in this repository. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

## before

```
$ misspell .
build/pom-templates/pom-reladomo-test-util.xml:29:41: "faciliate" is a misspelling of "facilitate"
libboot/src/main/java/org/libboot/Libboot.java:45:35: "UNKOWN" is a misspelling of "UNKNOWN"
libboot/src/main/java/org/libboot/Libboot.java:186:29: "UNKOWN" is a misspelling of "UNKNOWN"
reladomo/src/doc/docbook/mithraTestResource/ReladomoTestResource.xml:80:86: "neccesary" is a misspelling of "necessary"
reladomo/src/doc/docbook/mithraddl/ReladomoDdlGenerator.xml:82:93: "Acceptible" is a misspelling of "Acceptable"
reladomo/src/doc/docbook/presentations/reladomoInternalCacheStructure/ReladomoInternalCacheStructure.xml:347:45: "overriden" is a misspelling of "overridden"
reladomo/src/doc/docbook/mithrafaq/ReladomoFaq.xml:1906:20: "createin" is a misspelling of "creatine"
reladomo/src/main/grammar/mithra.jjt:2:8: "grammer" is a misspelling of "grammar"
reladomo/src/main/java/com/gs/fw/common/mithra/MithraManager.java:648:7: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/MithraManager.java:660:7: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java:525:68: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java:535:68: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java:540:68: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java:545:68: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java:550:68: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/AbstractNonDatedCache.java:555:68: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/offheap/FastUnsafeOffHeapIntArrayStorage.java:322:55: "terrabyte" is a misspelling of "terabyte"
reladomo/src/main/java/com/gs/fw/common/mithra/cache/offheap/FastUnsafeOffHeapDataStorage.java:984:55: "terrabyte" is a misspelling of "terabyte"
reladomo/src/main/java/com/gs/fw/common/mithra/cacheloader/DependentLoaderFactoryImpl.java:371:56: "cannnot" is a misspelling of "cannot"
reladomo/src/main/java/com/gs/fw/common/mithra/cacheloader/DependentLoaderFactoryImpl.java:377:56: "cannnot" is a misspelling of "cannot"
reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/AbstractConnectionManager.java:345:16: "intial" is a misspelling of "initial"
reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionPoolingDataSource.java:322:24: "commited" is a misspelling of "committed"
reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionPoolingDataSource.java:443:15: "commited" is a misspelling of "committed"
reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionPoolingDataSource.java:495:15: "commited" is a misspelling of "committed"
reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionPoolingDataSource.java:506:16: "commited" is a misspelling of "committed"
reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraCodeGeneratedDatabaseObject.java:39:7: "retreive" is a misspelling of "retrieve"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:39:44: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:41:44: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:42:44: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:43:44: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:367:51: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:368:51: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:369:51: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/Udb82DatabaseType.java:370:51: "EXISTANT" is a misspelling of "EXISTENT"
reladomo/src/main/java/com/gs/fw/common/mithra/finder/AsOfEqualityChecker.java:448:37: "boundry" is a misspelling of "boundary"
reladomo/src/main/java/com/gs/fw/common/mithra/finder/SqlParameterSetter.java:28:33: "statment" is a misspelling of "statement"
reladomo/src/main/java/com/gs/fw/common/mithra/list/AdhocDetachedList.java:174:25: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/remote/RemoteMithraServiceImpl.java:98:110: "existant" is a misspelling of "existent"
reladomo/src/main/java/com/gs/fw/common/mithra/remote/RemoteMithraServiceImpl.java:156:102: "existant" is a misspelling of "existent"
reladomo/src/main/java/com/gs/fw/common/mithra/remote/RemoteMithraServiceImpl.java:172:102: "existant" is a misspelling of "existent"
reladomo/src/main/java/com/gs/fw/common/mithra/remote/RemoteMithraServiceImpl.java:453:102: "existant" is a misspelling of "existent"
reladomo/src/main/java/com/gs/fw/common/mithra/transaction/MithraRootTransaction.java:789:21: "desparate" is a misspelling of "desperate"
reladomo/src/main/java/com/gs/fw/common/mithra/transaction/MithraRootTransaction.java:930:66: "commited" is a misspelling of "committed"
reladomo/src/main/java/com/gs/fw/common/mithra/util/MultiQueueExecutor.java:41:86: "extrenally" is a misspelling of "externally"
reladomo/src/main/java/com/gs/fw/common/mithra/util/MithraConfigurationManager.java:103:7: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/util/MithraConfigurationManager.java:115:7: "overriden" is a misspelling of "overridden"
reladomo/src/main/java/com/gs/fw/common/mithra/util/SingleQueueExecutor.java:48:86: "extrenally" is a misspelling of "externally"
reladomo/src/main/java/com/gs/reladomo/util/Base64.java:388:27: "accomodate" is a misspelling of "accommodate"
reladomo/src/main/java/com/gs/reladomo/util/Base64.java:919:27: "accomodate" is a misspelling of "accommodate"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBasicRetrieval.java:309:116: "availble" is a misspelling of "available"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBigDecimal.java:503:34: "excpetion" is a misspelling of "exception"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestBigDecimal.java:516:34: "excpetion" is a misspelling of "exception"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTempObject.java:720:39: "destory" is a misspelling of "destroy"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTempObject.java:732:39: "destory" is a misspelling of "destroy"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTempObject.java:738:45: "destory" is a misspelling of "destroy"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTempObject.java:739:45: "destory" is a misspelling of "destroy"
reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTransactionalObject.java:2832:23: "commited" is a misspelling of "committed"
reladomo/src/test/java/com/gs/fw/common/mithra/test/aggregate/TestAggregationWithHavingClause.java:1378:24: "undertsand" is a misspelling of "understands"
reladomo/src/test/java/com/gs/fw/common/mithra/test/cacheloader/DependentLoaderFactoryTest.java:234:48: "cannnot" is a misspelling of "cannot"
reladomo/src/test/java/com/gs/fw/common/mithra/test/tinyproxy/EchoImpl.java:93:73: "PRIMATIVES" is a misspelling of "PRIMITIVES"
reladomo/src/test/java/com/gs/fw/common/mithra/test/util/tinyproxy/StreamBasedInvocator.java:115:47: "occured" is a misspelling of "occurred"
reladomo/src/test/reladomo-xml/Filing.xml:84:82: "RECIEVED" is a misspelling of "RECEIVED"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:27:20: "occured" is a misspelling of "occurred"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:32:17: "wass" is a misspelling of "was"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:106:57: "occured" is a misspelling of "occurred"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:107:50: "occured" is a misspelling of "occurred"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:108:52: "occured" is a misspelling of "occurred"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:109:62: "occured" is a misspelling of "occurred"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/MithraObjectTypeWrapper.java:1695:75: "overriden" is a misspelling of "overridden"
reladomogen/src/main/xsd/mithraobject.xsd:748:52: "foregin" is a misspelling of "foreign"
samples/reladomo-sample-simple/src/main/resources/reladomo/models/reladomoobject.xsd:833:52: "foregin" is a misspelling of "foreign"
```

## after

```
$ misspell .
reladomo/src/doc/docbook/mithrafaq/ReladomoFaq.xml:1906:20: "createin" is a misspelling of "creatine"
reladomogen/src/main/java/com/gs/fw/common/mithra/generator/queryparser/TokenMgrError.java:32:17: "wass" is a misspelling of "was"
```