### PR TITLE
multi threaded deep fetch exception handling

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/DeepFetchNode.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/DeepFetchNode.java
@@ -74,13 +74,11 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
         }
     };
 
-    private long queryTime;
     private DeepFetchNode parent;
     private FastList<DeepFetchNode> children;
     private transient List cachedQueryList;
     private AbstractRelatedFinder relatedFinder;
     private Operation originalOperation;
-    private Operation simplifiedOperation;
     private boolean resolved = false;
     private boolean fullyResolved = false;
     private transient List resolvedList;
@@ -221,10 +219,8 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
                 new ThreadConservingExecutor(numberOfParallelThreads);
         this.resolvedList = resolved.getResult();
         this.originalOperation = resolved.getOperation();
-        if (queryTime != 0) this.queryTime = queryTime;
         DeepFetchRunnable parent = new DeepFetchRunnable(null, bypassCache, executor, forceImplicitJoin);
         deepFetchChildren(bypassCache, executor, parent, forceImplicitJoin);
-        parent.waitForChildren();
         executor.finish();
         this.resolved = true;
         this.fullyResolved = true;
@@ -1073,21 +1069,6 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
         {
             fullyResolved = true;
             decrementParent();
-        }
-
-        private synchronized void waitForChildren()
-        {
-            while(childCount > 0)
-            {
-                try
-                {
-                    this.wait();
-                }
-                catch (InterruptedException e)
-                {
-                    //ignore
-                }
-            }
         }
 
         private synchronized boolean decrementChildCount()

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraTestSuite.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraTestSuite.java
@@ -120,6 +120,7 @@ public class MithraTestSuite
         suite.addTestSuite(TestDirectRefRelationships.class);
         suite.addTestSuite(TestDatedBasicRetrieval.class);
         suite.addTestSuite(SelfJoinTest.class);
+        suite.addTestSuite(MultiThreadDeepFetchTest.class);
         suite.addTestSuite(TestDeepFetchExternalClose.class);
         suite.addTestSuite(EdgePointDeepFetchOnProcessingTemporalTest.class);
         suite.addTestSuite(TestQueryCacheBehavior.class);

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MultiThreadDeepFetchTest.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MultiThreadDeepFetchTest.java
@@ -1,0 +1,100 @@
+/*
+ Copyright 2016 Goldman Sachs.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+package com.gs.fw.common.mithra.test;
+
+import com.gs.fw.common.mithra.MithraManagerProvider;
+import com.gs.fw.common.mithra.finder.Operation;
+import com.gs.fw.common.mithra.test.domain.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.sql.Timestamp;
+
+public class MultiThreadDeepFetchTest extends MithraTestAbstract
+{
+    @Override
+    protected Class[] getRestrictedClassList ()
+    {
+        Set<Class> result = new HashSet<Class> ();
+        result.add (Projito.class);
+        result.add (ProjitoVersion.class);
+        result.add (ProjitoMembership.class);
+        result.add (ProjitoMeasureOfSuccess.class);
+        result.add (ProjitoEmployee.class);
+        result.add (ProjitoAddress.class);
+
+        Class[] array = new Class[result.size ()];
+        result.toArray (array);
+        return array;
+    }
+
+
+    public void testFiveThreadDeepFetch ()
+    {
+        Operation op = ProjitoVersionFinder.processingDate ().eq (Timestamp.valueOf ("2018-08-28 00:00:00")).and (ProjitoVersionFinder.versionedRoot ().id ().eq (2L));
+
+        ProjitoVersionList projitoVersions = ProjitoVersionFinder.findManyBypassCache (op);
+
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().memberships ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().memberships ().employee ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().memberships ().employee ().addresses ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().measuresOfSuccess ().accountableEmployee ().addresses ());
+
+        projitoVersions.setOrderBy (ProjitoVersionFinder.number ().descendingOrderBy ());
+        projitoVersions.setNumberOfParallelThreads (5);
+        assertEquals (1, projitoVersions.size ());
+
+        int countBeforeGetters = MithraManagerProvider.getMithraManager ().getDatabaseRetrieveCount ();
+
+        ProjitoAddressList addresses = projitoVersions.get (0).getVersionedRoot ().getMemberships ().get (0).getEmployee ().getAddresses ();
+        assertEquals (2, addresses.size ());
+
+        ProjitoMeasureOfSuccessList measuresOfSuccess = projitoVersions.get (0).getVersionedRoot ().getMeasuresOfSuccess ();
+        assertEquals (2, measuresOfSuccess.size ());
+        assertEquals (2, measuresOfSuccess.get (0).getAccountableEmployee ().getAddresses ().size ());
+        assertEquals (1, measuresOfSuccess.get (1).getAccountableEmployee ().getAddresses ().size ());
+
+        assertEquals (countBeforeGetters, MithraManagerProvider.getMithraManager ().getDatabaseRetrieveCount ());
+    }
+
+    public void testCompletesAfterExceptionThrown ()
+    {
+        Operation op = ProjitoFinder.processingDate ().eq (Timestamp.valueOf ("2018-08-28 00:00:00")).and (ProjitoFinder.id ().eq (2L));
+
+        ProjitoList projitoVersions = ProjitoFinder.findManyBypassCache (op);
+
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().memberships ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().memberships ().employee ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().memberships ().employee ().addresses ());
+        projitoVersions.deepFetch (ProjitoVersionFinder.versionedRoot ().measuresOfSuccess ().accountableEmployee ().addresses ());
+
+        projitoVersions.setOrderBy (ProjitoVersionFinder.number ().descendingOrderBy ());
+        projitoVersions.setNumberOfParallelThreads (5);
+        try
+        {
+            projitoVersions.size ();
+            fail();
+        } catch (ClassCastException e)
+        {
+            // expected exception
+        }
+
+    }
+
+}


### PR DESCRIPTION
DeepFetchRunnable did not handle the exceptions. In case of an exception, it did not count down the children and the main thread was blocked indefinitely in waitForChildren(). The ThreadConservingExecutor is responsible for handling exceptions in runnable and count down the tasks. I removed the DeepFetchRunnable .waitForcChildren() and moved responsibility to wait for all tasks to the ThreadConservingExecutor.finish().