### PR TITLE
Clean Notification Manager Shutdown

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/notification/MithraNotificationEventManagerImpl.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/notification/MithraNotificationEventManagerImpl.java
@@ -716,7 +716,13 @@ public class MithraNotificationEventManagerImpl implements MithraNotificationEve
         adapterFactory.shutdown();
         if (!fromShutdownHook && this.shutdownHook != null)
         {
-            Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+            try
+            {
+                Runtime.getRuntime ().removeShutdownHook (this.shutdownHook);
+            } catch (IllegalStateException ex)
+            {
+                logger.info("The virtual machine is already in the process of shutting down.", ex);
+            }
         }
         this.shutdownHook = null;
     }


### PR DESCRIPTION
Notification thread can receive shutdown order during the JVM shutdown sequence. The System call will throw InvalidStateException in this conditions. Gracefully handling this exception to reduce confusion.