### PR TITLE
Fixes for concurrent notification during deep fetch

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/AbstractRelatedFinder.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/AbstractRelatedFinder.java
@@ -61,7 +61,7 @@ public abstract class AbstractRelatedFinder<ReturnType, ParentOwnerType, ReturnO
     {
     }
 
-    private DeepFetchStrategy getDeepFetchStrategy()
+    public DeepFetchStrategy zGetDeepFetchStrategy()
     {
         DeepFetchStrategy strategy = this.deepFetchStrategy;
         if (strategy == null)
@@ -81,6 +81,11 @@ public abstract class AbstractRelatedFinder<ReturnType, ParentOwnerType, ReturnO
             this.deepFetchStrategy = strategy;
         }
         return strategy;
+    }
+
+    public void zSetDeepFetchStrategy(DeepFetchStrategy deepFetchStrategy)
+    {
+        this.deepFetchStrategy = deepFetchStrategy;
     }
 
     public Mapper zGetMapper()
@@ -303,7 +308,7 @@ public abstract class AbstractRelatedFinder<ReturnType, ParentOwnerType, ReturnO
 
     public List zDeepFetch(DeepFetchNode node, boolean bypassCache, boolean forceImplicitJoin)
     {
-        DeepFetchStrategy strategy = this.getDeepFetchStrategy();
+        DeepFetchStrategy strategy = this.zGetDeepFetchStrategy();
         if (strategy != null)
         {
             return strategy.deepFetch(node, bypassCache, forceImplicitJoin);
@@ -313,7 +318,7 @@ public abstract class AbstractRelatedFinder<ReturnType, ParentOwnerType, ReturnO
 
     public DeepFetchResult zDeepFetchFirstLinkInMemory(DeepFetchNode node)
     {
-        DeepFetchStrategy strategy = this.getDeepFetchStrategy();
+        DeepFetchStrategy strategy = this.zGetDeepFetchStrategy();
         if (strategy != null)
         {
             return strategy.deepFetchFirstLinkInMemory(node);
@@ -323,12 +328,12 @@ public abstract class AbstractRelatedFinder<ReturnType, ParentOwnerType, ReturnO
 
     public List zFinishAdhocDeepFetch(DeepFetchNode deepFetchNode, DeepFetchResult result)
     {
-        return this.getDeepFetchStrategy().finishAdhocDeepFetch(deepFetchNode, result);
+        return this.zGetDeepFetchStrategy().finishAdhocDeepFetch(deepFetchNode, result);
     }
 
     public List zDeepFetchWithTempContext(DeepFetchNode node, TupleTempContext tempContext, Object parentPrototype, List immediateParentList)
     {
-        return this.getDeepFetchStrategy().deepFetchAdhocUsingTempContext(node, tempContext, parentPrototype, immediateParentList);
+        return this.zGetDeepFetchStrategy().deepFetchAdhocUsingTempContext(node, tempContext, parentPrototype, immediateParentList);
     }
 
     public RelationshipMultiExtractor zGetRelationshipMultiExtractor()
@@ -348,12 +353,12 @@ public abstract class AbstractRelatedFinder<ReturnType, ParentOwnerType, ReturnO
 
     public List zDeepFetchWithInClause(DeepFetchNode deepFetchNode, Attribute singleAttribute, List parentList)
     {
-        return this.getDeepFetchStrategy().deepFetchAdhocUsingInClause(deepFetchNode, singleAttribute, parentList);
+        return this.zGetDeepFetchStrategy().deepFetchAdhocUsingInClause(deepFetchNode, singleAttribute, parentList);
     }
 
     public boolean zCanFinishAdhocDeepFetchResult()
     {
-        return this.getDeepFetchStrategy().canFinishAdhocDeepFetchResult();
+        return this.zGetDeepFetchStrategy().canFinishAdhocDeepFetchResult();
     }
 
     @Override

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/ChainedDeepFetchStrategy.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/ChainedDeepFetchStrategy.java
@@ -76,7 +76,7 @@ public class ChainedDeepFetchStrategy extends DeepFetchStrategy
             List list = ((DeepFetchStrategy) chainedStrategies.get(i)).deepFetch(node, bypassCache, forceImplicitJoin);
             if (list == null)
             {
-                node.setResolvedList(ListFactory.EMPTY_LIST, i);
+                node.setResolvedList(ListFactory.EMPTY_LIST, i, node.getImmediateParentCachedQuery(i));
             }
             else
             {
@@ -103,7 +103,7 @@ public class ChainedDeepFetchStrategy extends DeepFetchStrategy
             List list = ((DeepFetchStrategy) chainedStrategies.get(i)).deepFetchAdhocUsingTempContext(node, tempContext, parentPrototype, immediateParentList);
             if (list == null)
             {
-                node.setResolvedList(ListFactory.EMPTY_LIST, i);
+                node.setResolvedList(ListFactory.EMPTY_LIST, i, null);
             }
             else
             {

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/DeepFetchNode.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/DeepFetchNode.java
@@ -27,26 +27,13 @@ import com.gs.fw.common.mithra.extractor.IdentityExtractor;
 import com.gs.fw.common.mithra.notification.MithraDatabaseIdentifierExtractor;
 import com.gs.fw.common.mithra.querycache.CachedQuery;
 import com.gs.fw.common.mithra.tempobject.TupleTempContext;
-import com.gs.fw.common.mithra.util.ExecutorWithFinish;
-import com.gs.fw.common.mithra.util.HashUtil;
-import com.gs.fw.common.mithra.util.InternalList;
-import com.gs.fw.common.mithra.util.ListFactory;
-import com.gs.fw.common.mithra.util.MithraFastList;
-import com.gs.fw.common.mithra.util.MultiHashMap;
-import com.gs.fw.common.mithra.util.PersisterId;
-import com.gs.fw.common.mithra.util.ThreadConservingExecutor;
+import com.gs.fw.common.mithra.util.*;
 import com.gs.fw.finder.Navigation;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Executor;
 
 
@@ -82,7 +69,9 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
     private boolean resolved = false;
     private boolean fullyResolved = false;
     private transient List resolvedList;
+    private transient CachedQuery resolvedCachedQuery;
     private transient List[] chainedResults;
+    private transient CachedQuery[] chainedCachedQueries;
     private static final int PERCENT_COMPLETE_TO_IGNORE = 80;
     private static final ExecutorWithFinish CURRENT_THREAD_EXECUTOR = new CurrentThreadExecutorService();
 
@@ -107,7 +96,9 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
             result.cachedQueryList = FastList.newList(this.cachedQueryList);
         }
         result.resolvedList = this.resolvedList;
+        result.resolvedCachedQuery = this.resolvedCachedQuery;
         result.chainedResults = this.chainedResults;
+        result.chainedCachedQueries = this.chainedCachedQueries;
         if (children != null)
         {
             result.children = FastList.newList(children.size());
@@ -128,13 +119,28 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
 
     public void setResolvedList(List resolvedList, int chainPosition)
     {
+        setResolvedList(resolvedList, chainPosition, null);
+    }
+
+    /**
+     * Records the results of the deep fetch query for this node, e.g. for consumption by the child node.
+     * @param resolvedList The resolved query results for this node
+     * @param chainPosition The chain position, or zero if not applicable
+     * @param resolvedCachedQuery An optional CachedQuery which may be used to determine if the query results may have expired.
+     *                            Note: this query does not need to return the correct result set, it is merely indicative of cache expiry.
+     *                            Set to null if not applicable.
+     */
+    public void setResolvedList(List resolvedList, int chainPosition, CachedQuery resolvedCachedQuery)
+    {
         if (chainedResults == null || chainPosition == chainedResults.length - 1)
         {
             this.resolvedList = resolvedList;
+            this.resolvedCachedQuery = resolvedCachedQuery;
         }
         else
         {
             this.chainedResults[chainPosition] = resolvedList;
+            this.chainedCachedQueries[chainPosition] = resolvedCachedQuery;
         }
     }
 
@@ -218,6 +224,7 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
         ExecutorWithFinish executor = numberOfParallelThreads == 1 ? CURRENT_THREAD_EXECUTOR :
                 new ThreadConservingExecutor(numberOfParallelThreads);
         this.resolvedList = resolved.getResult();
+        this.resolvedCachedQuery = resolved;
         this.originalOperation = resolved.getOperation();
         DeepFetchRunnable parent = new DeepFetchRunnable(null, bypassCache, executor, forceImplicitJoin);
         deepFetchChildren(bypassCache, executor, parent, forceImplicitJoin);
@@ -268,14 +275,16 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
         if (!resolved)
         {
             this.resolvedList = ListFactory.EMPTY_LIST;
+            this.resolvedCachedQuery = null;
             this.resolved = true;
 
             Operation rootOperation = this.getRootOperation();
             if (rootOperation != null)
             {
-                CachedQuery query = new CachedQuery(this.relatedFinder.zGetMapper().createMappedOperationForDeepFetch(rootOperation), null);
+                CachedQuery query = new CachedQuery(this.relatedFinder.zGetMapper().createMappedOperationForDeepFetch(rootOperation), null, this.getParent().getResolvedCachedQuery());
                 query.setResult(this.resolvedList);
                 query.cacheQuery(true);
+                this.resolvedCachedQuery = query;
             }
         }
     }
@@ -327,6 +336,16 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
         return resolvedList;
     }
 
+    /**
+     * Returns an optional CachedQuery, solely for the purpose of determining if the query results may be stale.
+     * This query need not necessarily correspond to the same result set - it is merely indicative of cache expiry.
+     * Returns null if not applicable.
+     */
+    public CachedQuery getResolvedCachedQuery()
+    {
+        return resolvedCachedQuery;
+    }
+
     private Operation getRootOperation()
     {
         DeepFetchNode cur = this;
@@ -352,6 +371,7 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
             this.fullyResolved = false;
             this.resolved = false;
             this.resolvedList = null;
+            this.resolvedCachedQuery = null;
             this.cachedQueryList = null;
         }
     }
@@ -360,6 +380,7 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
     {
         if (this.fullyResolved) return;
         this.resolvedList = resolved.getResult();
+        this.resolvedCachedQuery = resolved;
         this.originalOperation = resolved.getOperation();
         incrementalDeepFetchChildren(bypassCache, forceImplicitJoin);
         this.fullyResolved = true;
@@ -387,6 +408,18 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
         else
         {
             return chainedResults[chainPosition - 1];
+        }
+    }
+
+    public CachedQuery getImmediateParentCachedQuery(int chainPosition)
+    {
+        if (chainPosition == 0)
+        {
+            return this.parent.getResolvedCachedQuery();
+        }
+        else
+        {
+            return chainedCachedQueries[chainPosition - 1];
         }
     }
 
@@ -870,6 +903,7 @@ public class DeepFetchNode implements Serializable, DeepFetchTree
     public void allocatedChainedResults(int size)
     {
         this.chainedResults = new List[size];
+        this.chainedCachedQueries = new CachedQuery[size];
     }
 
     // mapper is not necessarily this.relatedFinder.mapper. chained mapper and linked mapper's callbacks.

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/DeepRelationshipUtility.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/DeepRelationshipUtility.java
@@ -37,7 +37,8 @@ public class DeepRelationshipUtility
 
     private static final InternalList EMPTY_INTERNAL_LIST = new InternalList(0);
 
-    protected static int MAX_SIMPLIFIED_IN = 1000;
+    private static final int DEFAULT_MAX_SIMPLIFIED_IN = 1000;
+    protected static int MAX_SIMPLIFIED_IN = DEFAULT_MAX_SIMPLIFIED_IN;
 
     private DeepRelationshipUtility()
     {
@@ -52,6 +53,11 @@ public class DeepRelationshipUtility
     public static void setMaxSimplifiedIn(int max)
     {
         MAX_SIMPLIFIED_IN = max;
+    }
+
+    public static void resetMaxSimplifiedIn()
+    {
+        setMaxSimplifiedIn(DEFAULT_MAX_SIMPLIFIED_IN);
     }
 
     public static Logger getLogger()

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/finder/sqcache/SubQueryCache.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/finder/sqcache/SubQueryCache.java
@@ -61,14 +61,14 @@ public class SubQueryCache
             toFind = analyzedOperation.getAnalyzedOperation();
         }
         CachedQuery result = null;
-        for(int i=0;i<MAX_REFS;i++)
+        for(int i = 0; i<MAX_REFS; i++)
         {
             CachedQuery query = unwrap(hashTable[i]);
             if (query != null)
             {
                 ShapeMatchResult shapeMatchResult = toFind.zShapeMatch(query.getOperation());
                 List resolved = shapeMatchResult.resolve(cache);
-                result = createAndCacheCachedQuery(op, analyzedOperation, orderBy, cache, forRelationship, resolved);
+                result = createAndCacheCachedQuery(op, analyzedOperation, orderBy, cache, forRelationship, resolved, query);
             }
         }
         if (result != null) return result;
@@ -76,12 +76,12 @@ public class SubQueryCache
         CachedQuery all = unwrap(allOperation);
         if (all != null && all.getOperation().getResultObjectPortal() == toFind.getResultObjectPortal() && toFind.zCanFilterInMemory())
         {
-            result = createAndCacheCachedQuery(op, analyzedOperation, orderBy, cache, forRelationship, op.applyOperation(all.getResult()));
+            result = createAndCacheCachedQuery(op, analyzedOperation, orderBy, cache, forRelationship, op.applyOperation(all.getResult()), all);
         }
         return result;
     }
 
-    private CachedQuery createAndCacheCachedQuery(Operation op, AnalyzedOperation analyzedOperation, OrderBy orderBy, QueryCache cache, boolean forRelationship, List resolved)
+    private CachedQuery createAndCacheCachedQuery(Operation op, AnalyzedOperation analyzedOperation, OrderBy orderBy, QueryCache cache, boolean forRelationship, List resolved, CachedQuery originatingCachedQuery)
     {
         if (resolved != null)
         {
@@ -90,12 +90,12 @@ public class SubQueryCache
             boolean wasDefaulted = analyzedOperation != null && analyzedOperation.isAnalyzedOperationDifferent();
             if (wasDefaulted)
             {
-                CachedQuery query2 = new CachedQuery(analyzedOperation.getAnalyzedOperation(), orderBy);
+                CachedQuery query2 = new CachedQuery(analyzedOperation.getAnalyzedOperation(), orderBy, originatingCachedQuery);
                 query2.setResult(resolved);
                 cache.cacheQueryForSubQuery(query2, forRelationship);
             }
 
-            CachedQuery result = new CachedQuery(op, orderBy);
+            CachedQuery result = new CachedQuery(op, orderBy, originatingCachedQuery);
             result.setResult(resolved);
             if (wasDefaulted)
             {

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/portal/MithraTransactionalPortal.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/portal/MithraTransactionalPortal.java
@@ -17,12 +17,7 @@
 
 package com.gs.fw.common.mithra.portal;
 
-import com.gs.fw.common.mithra.MithraDataObject;
-import com.gs.fw.common.mithra.MithraManagerProvider;
-import com.gs.fw.common.mithra.MithraObjectDeserializer;
-import com.gs.fw.common.mithra.MithraObjectPortal;
-import com.gs.fw.common.mithra.MithraTransaction;
-import com.gs.fw.common.mithra.MithraTransactionalObject;
+import com.gs.fw.common.mithra.*;
 import com.gs.fw.common.mithra.behavior.TemporalContainer;
 import com.gs.fw.common.mithra.behavior.state.PersistenceState;
 import com.gs.fw.common.mithra.behavior.txparticipation.FullTransactionalParticipationMode;
@@ -338,8 +333,9 @@ public class MithraTransactionalPortal extends MithraAbstractObjectPortal
     protected CachedQuery findInCacheForTransaction(AnalyzedOperation analyzedOperation, OrderBy orderby,
             MithraTransaction tx, boolean forRelationship, Operation op)
     {
+        CachedQuery emptyNewCachedQuery = new CachedQuery(op, orderby); // must create before executing the query to avoid a race condition against concurrent updates
         List resultList = applyOperationAndCheck(analyzedOperation != null ? analyzedOperation.getAnalyzedOperation() : op, tx);
-        return this.createAndCacheQuery(resultList, orderby, op, analyzedOperation, forRelationship);
+        return this.createAndCacheQuery(resultList, orderby, analyzedOperation, forRelationship, emptyNewCachedQuery);
     }
 
     /* returns null if the members of the list are not all participating in the transaction */

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraTestSuite.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraTestSuite.java
@@ -22,11 +22,7 @@ import com.gs.fw.common.mithra.test.database.SyslogCheckerTest;
 import com.gs.fw.common.mithra.test.domain.inherited.TestIndexCreation;
 import com.gs.fw.common.mithra.test.evo.TestEmbeddedValueObjects;
 import com.gs.fw.common.mithra.test.finalgetter.TestFinalGetters;
-import com.gs.fw.common.mithra.test.h2batch.TestH2DefaultBatchSizeTestCases;
-import com.gs.fw.common.mithra.test.h2batch.TestH2LargeBatchSizeTestCases;
-import com.gs.fw.common.mithra.test.h2batch.TestH2NegativeBatchSizeTestCases;
-import com.gs.fw.common.mithra.test.h2batch.TestH2SmallBatchSizeTestCases;
-import com.gs.fw.common.mithra.test.h2batch.TestH2ZeroBatchSizeTestCases;
+import com.gs.fw.common.mithra.test.h2batch.*;
 import com.gs.fw.common.mithra.test.inherited.TestReadOnlyInherited;
 import com.gs.fw.common.mithra.test.inherited.TestTxInherited;
 import com.gs.fw.common.mithra.test.mithrainterface.TestMithraInterfaceType;
@@ -59,6 +55,7 @@ public class MithraTestSuite
         TestSuite suite = new TestSuite();
         suite.addTestSuite(TestConnectionManager.class);
         suite.addTestSuite(TestCursor.class);
+        suite.addTestSuite(TestCachedQueryClass.class);
 
         suite.addTestSuite(TestRelationshipPersistence.class);
         suite.addTestSuite(TestListMerge.class);
@@ -148,6 +145,7 @@ public class MithraTestSuite
         suite.addTestSuite(TestDetachedOptimisticAuditOnly.class);
         suite.addTestSuite(TestUpdateListener.class);
         suite.addTestSuite(TestAdhocDeepFetch.class);
+        suite.addTestSuite(TestNotificationDuringDeepFetch.class);
         suite.addTestSuite(TestCrossDatabaseAdhocDeepFetch.class);
         suite.addTestSuite(TestTransactionalObjectAttributesBehavior.class);
 

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestCachedQueryClass.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestCachedQueryClass.java
@@ -1,0 +1,250 @@
+package com.gs.fw.common.mithra.test;
+
+import com.gs.fw.common.mithra.finder.Operation;
+import com.gs.fw.common.mithra.finder.orderby.OrderBy;
+import com.gs.fw.common.mithra.querycache.CachedQuery;
+import com.gs.fw.common.mithra.tempobject.TupleTempContext;
+import com.gs.fw.common.mithra.test.domain.OrderFinder;
+import com.gs.fw.common.mithra.test.domain.OrderStatusFinder;
+import org.junit.Assert;
+
+public class TestCachedQueryClass extends MithraTestAbstract
+{
+    public void testUpdateCountersCopyFromFirstReflectsFirstBecomingStale()
+    {
+        // These two ops are unrelated so have different update count holders
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderStatusFinder.status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery secondCopiedFromFirst = new CachedQuery(secondOp, secondOrderBy, first); // note: copy from first, not merge
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(secondCopiedFromFirst.isExpired());
+
+        // Invalidate the first cached query
+        OrderFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertTrue(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertTrue(secondCopiedFromFirst.isExpired());
+
+        final CachedQuery newSecondCopiedFromFirst = new CachedQuery(secondOp, secondOrderBy, first);
+        Assert.assertTrue(newSecondCopiedFromFirst.isExpired());// should be expired even though newly created, as first is still stale
+    }
+
+    public void testUpdateCountersCopyFromFirstDoesNotReflectUpdateCountsOfSecond()
+    {
+        // These two ops are unrelated so have different update count holders
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderStatusFinder.status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery secondCopiedFromFirst = new CachedQuery(secondOp, secondOrderBy, first); // note: copy from first, not merge
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(secondCopiedFromFirst.isExpired());
+
+        // Invalidate the second cached query
+        OrderStatusFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertTrue(second.isExpired());
+        Assert.assertFalse(secondCopiedFromFirst.isExpired());
+    }
+
+    public void testUpdateCountersMergeOfUnrelatedOpsIncludesFirst()
+    {
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderStatusFinder.status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(combined.isExpired());
+
+        // Invalidate the first cached query
+        OrderFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertTrue(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+
+        final CachedQuery newCombined = new CachedQuery(secondOp, secondOrderBy, first, true);
+        Assert.assertTrue(newCombined.isExpired());// should be expired even though newly created, as first is still stale
+    }
+
+    public void testUpdateCountersMergeOfUnrelatedOpsIncludesSecond()
+    {
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderStatusFinder.status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(combined.isExpired());
+
+        // Invalidate the second cached query
+        OrderStatusFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertTrue(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+
+        final CachedQuery newCombined = new CachedQuery(secondOp, secondOrderBy, first, true);
+        Assert.assertFalse(newCombined.isExpired()); // should not be expired as newCombined contains the latest update counters for the second operation
+    }
+
+    public void testUpdateCountersMergeOfRelatedOpsRetainsTheOlderUpdateCountOfFirst()
+    {
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderFinder.orderStatus().status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        Assert.assertFalse(first.isExpired());
+
+        // Invalidate the parent table which both queries should depend on, before the second cached query has snapshotted it
+        OrderFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertTrue(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+    }
+
+    public void testUpdateCountersMergeOfRelatedOpsMergesEquivalentCounts()
+    {
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderFinder.orderStatus().status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(combined.isExpired());
+
+        // Invalidate the parent table which both queries should depend on
+        OrderFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertTrue(first.isExpired());
+        Assert.assertTrue(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+    }
+
+    public void testUpdateCountersMergeOfRelatedOpsIncludesAdditionalDependenciesOfSecond()
+    {
+        final Operation firstOp = OrderFinder.state().eq("In-Progress");
+        final Operation secondOp = OrderFinder.orderStatus().status().eq(10);
+
+        final OrderBy firstOrderBy = OrderFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(combined.isExpired());
+
+        // Invalidate the child table which only the second op should depend on
+        OrderStatusFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertTrue(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+
+        final CachedQuery newCombined = new CachedQuery(secondOp, secondOrderBy, first, true);
+        Assert.assertFalse(newCombined.isExpired()); // should not be expired as newCombined contains the latest update counters for the second operation
+    }
+
+    public void testUpdateCountersMergeOnTempObjectAsFirst()
+    {
+        final TupleTempContext tupleTempContext = new TupleTempContext(OrderFinder.allPersistentAttributes(), true);
+        final Operation firstOp = tupleTempContext.all();
+        final Operation secondOp = OrderStatusFinder.status().eq(10);
+
+        final OrderBy firstOrderBy = tupleTempContext.getTupleAttributesAsAttributeArray()[0].ascendingOrderBy();
+        final OrderBy secondOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(combined.isExpired());
+
+        // There is no way to invalidate a temp context cached query - it has no update counters.
+        // Invalidate the second cached query
+        OrderStatusFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertTrue(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+
+        final CachedQuery newCombined = new CachedQuery(secondOp, secondOrderBy, first, true);
+        Assert.assertFalse(newCombined.isExpired()); // should not be expired as newCombined contains the latest update counters for the second operation
+    }
+
+    public void testUpdateCountersMergeOnTempObjectAsSecond()
+    {
+        final TupleTempContext tupleTempContext = new TupleTempContext(OrderFinder.allPersistentAttributes(), true);
+        final Operation firstOp = OrderStatusFinder.status().eq(10);
+        final Operation secondOp = tupleTempContext.all();
+
+        final OrderBy firstOrderBy = OrderStatusFinder.orderId().ascendingOrderBy();
+        final OrderBy secondOrderBy = tupleTempContext.getTupleAttributesAsAttributeArray()[0].ascendingOrderBy();
+
+        final CachedQuery first = new CachedQuery(firstOp, firstOrderBy);
+        final CachedQuery second = new CachedQuery(secondOp, secondOrderBy);
+        final CachedQuery combined = new CachedQuery(secondOp, secondOrderBy, first, true);
+
+        Assert.assertFalse(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertFalse(combined.isExpired());
+
+        // There is no way to invalidate a temp context cached query - it has no update counters.
+        // Invalidate the first cached query
+        OrderStatusFinder.getMithraObjectPortal().incrementClassUpdateCount();
+
+        Assert.assertTrue(first.isExpired());
+        Assert.assertFalse(second.isExpired());
+        Assert.assertTrue(combined.isExpired());
+
+        final CachedQuery newCombined = new CachedQuery(secondOp, secondOrderBy, first, true);
+        Assert.assertTrue(newCombined.isExpired()); // should be expired even though newly created, as first is still stale
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestNotificationDuringDeepFetch.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestNotificationDuringDeepFetch.java
@@ -1,0 +1,807 @@
+/*
+ Copyright 2019 Goldman Sachs.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+package com.gs.fw.common.mithra.test;
+
+import com.gs.fw.common.mithra.MithraList;
+import com.gs.fw.common.mithra.MithraManagerProvider;
+import com.gs.fw.common.mithra.finder.*;
+import com.gs.fw.common.mithra.finder.orderby.OrderBy;
+import com.gs.fw.common.mithra.superclassimpl.MithraTransactionalObjectImpl;
+import com.gs.fw.common.mithra.test.domain.*;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+public class TestNotificationDuringDeepFetch extends MithraTestAbstract
+{
+    private static final Logger logger = LoggerFactory.getLogger(TestNotificationDuringDeepFetch.class.getName());
+
+    private MithraTestResource mithraTestResource;
+
+    private enum TimingTestCase
+    {
+        WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH,
+        WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE
+    }
+
+    private Semaphore signalWaitingForUpdate;
+    private Semaphore signalDoneUpdating;
+
+    protected void setUp() throws Exception
+    {
+        // Necessary to call parent setUp() as the runtime requires connection managers to be registered for all classes in the runtime config.
+        super.setUp();
+
+        // Here we override the test data we care about for this test.
+        // Modifying the original test data would have impacted a large number of existing tests.
+        mithraTestResource = buildMithraTestResource();
+        mithraTestResource.setRestrictedClassList(getRestrictedClassList());
+
+        ConnectionManagerForTests connectionManager = ConnectionManagerForTests.getInstance();
+        connectionManager.setDefaultSource("A");
+        connectionManager.setDatabaseTimeZone(this.getDatabaseTimeZone());
+        connectionManager.setDatabaseType(mithraTestResource.getDatabaseType());
+
+        mithraTestResource.createSingleDatabase(connectionManager, "A", MITHRA_TEST_DATA_FILE_PATH + "testNotificationDuringDeepFetch.txt");
+        mithraTestResource.setTestConnectionsOnTearDown(true);
+        mithraTestResource.setUp();
+
+        resetTestHarnessModifications();
+        signalWaitingForUpdate = new Semaphore(0);
+        signalDoneUpdating = new Semaphore(0);
+    }
+
+    private void resetTestHarnessModifications()
+    {
+        resetDeepFetchRelationship(OrderFinder.items());
+        resetDeepFetchRelationship(OrderFinder.orderStatus());
+        DeepRelationshipUtility.resetMaxSimplifiedIn();
+    }
+
+    @Override
+    protected void tearDown() throws Exception
+    {
+        super.tearDown();
+        resetTestHarnessModifications();
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenChildFetchAndCache_SimplifiedOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, false, false);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenChildFetchAndCache_ComplexOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, true, false);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenChildFetchAndCache_BypassCacheInPriorQuery_SimplifiedOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, false, true);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenChildFetchAndCache_BypassCacheInPriorQuery_ComplexOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, true, true);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenParentFetchAndChildFetch_SimplifiedOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, false, false);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenParentFetchAndChildFetch_ComplexOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, true, false);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenParentFetchAndChildFetch_BypassCacheInPriorQuery_SimplifiedOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, false, true);
+    }
+
+    public void testDeepFetch_OneToMany_NotificationBetweenParentFetchAndChildFetch_BypassCacheInPriorQuery_ComplexOp() throws Exception
+    {
+        runDeepFetchOneToManyTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, true, true);
+    }
+
+    private void runDeepFetchOneToManyTest(TimingTestCase timingTestCase, boolean forceComplexOp, boolean bypassCacheInPriorQuery) throws SQLException, InterruptedException
+    {
+        if (OrderFinder.isFullCache())
+        {
+            logger.info("Skipping test - deep fetch test cases are only applicable to partial cache runtime configuration");
+            return;
+        }
+
+        forceComplexOp(forceComplexOp);
+
+        final Operation op = OrderFinder.state().eq("In-Progress");
+        OrderList orderList = OrderFinder.findMany(op);
+        orderList.deepFetch(harnessDeepFetchRelationship(OrderFinder.items(), timingTestCase));
+
+        final Function<Order, Iterable<OrderItem>> getOrderItemsOfOrder = new Function<Order, Iterable<OrderItem>>()
+        {
+            @Override
+            public Iterable<OrderItem> valueOf(Order order)
+            {
+                return order.getItems();
+            }
+        };
+
+        final Predicate<OrderItem> orderItemStateEqualsInProgress = new Predicate<OrderItem>()
+        {
+            @Override
+            public boolean accept(OrderItem each)
+            {
+                return "In-Progress".equals(each.getState());
+            }
+        };
+
+        allowAllFetches();
+
+        Assert.assertEquals(4, orderList.size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderItemsOfOrder).size());
+        Assert.assertEquals(4, orderList.getItems().size());
+        Assert.assertEquals(4, orderList.getItems().asEcList().count(orderItemStateEqualsInProgress));
+
+        // This update and notification gives the findMany a reason to have to hit the database, as it marks the cache as dirty.
+        executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 55");
+        simulateOrderUpdateNotification(55, "state");
+
+        makeFetchesWaitForSignal();
+
+        // Simulate a database update and notification message occurring during the deep fetch
+        Thread thread = new Thread(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                waitToStartUpdateThread(); // wait until the deep fetch retrieval has reached the right point
+
+                executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 56");
+                executeAndAssertSqlUpdate(1, "update APP.ORDER_ITEM set STATE = 'In-Progress' where ID = 6 and ORDER_ID = 55");
+
+                simulateOrderUpdateNotification(56, "state");
+                simulateOrderItemUpdateNotification(6, "state");
+
+                signalUpdateThreadDone(); // allow the deep fetch to complete
+            }
+        });
+        thread.start();
+
+        OrderList orderList2 = OrderFinder.findMany(op);
+        orderList2.setBypassCache(bypassCacheInPriorQuery);
+        orderList2.deepFetch(harnessDeepFetchRelationship(OrderFinder.items(), timingTestCase));
+
+        logger.info("Performing deep fetch retrieval with concurrent database update and notification");
+
+        // The next call will resolve the deep fetch using the deep fetch strategy.
+        // The harnessed version of the deep fetch strategy coordinates with the update thread,
+        // to ensure the database updates are applied after the parent list is resolved but before the deep fetch was completed.
+        Assert.assertEquals(5, orderList2.size());
+        Assert.assertEquals(6, orderList2.asEcList().flatCollect(getOrderItemsOfOrder).size());
+
+        // This result includes OrderItem id 6 because Order.getItems() does a new finder query which hits the database due to the stale query cache.
+        // It gives the correct results but there is scope to optimise the performance if we could adopt a more sophisticated strategy.
+        Assert.assertEquals(6, orderList2.asEcList().flatCollect(getOrderItemsOfOrder).count(orderItemStateEqualsInProgress));
+
+        // Do not query orderList2.getItems() here or else it will re-fetch from database and that will mean the next deep fetch will hit the cache instead of the DB.
+        // The next part of the test is testing that the deep fetch hits the database to retrieve the updated Order 56, which triggers a re-fetch of OrderItem.
+
+        thread.join();
+
+        allowAllFetches();
+
+        // Should now reflect all updates to date as this is a brand new query
+        OrderList orderList3 = OrderFinder.findMany(op);
+        orderList3.deepFetch(harnessDeepFetchRelationship(OrderFinder.items(), timingTestCase));
+
+        logger.info("Performing final deep fetch retrieval");
+
+        final int retrievalCountBeforeFinalFetch = MithraManagerProvider.getMithraManager().getDatabaseRetrieveCount();
+
+        Assert.assertEquals(6, orderList3.size());
+
+        Assert.assertEquals(8, orderList3.asEcList().flatCollect(getOrderItemsOfOrder).size());
+        Assert.assertEquals(7, orderList3.asEcList().flatCollect(getOrderItemsOfOrder).count(orderItemStateEqualsInProgress));
+        Assert.assertEquals(8, orderList3.getItems().size());
+        Assert.assertEquals(7, orderList3.getItems().asEcList().count(orderItemStateEqualsInProgress));
+
+        final int retrievalCountAfterFinalFetch = MithraManagerProvider.getMithraManager().getDatabaseRetrieveCount();
+        final int retrievalCountDuringFinalFetch = retrievalCountAfterFinalFetch - retrievalCountBeforeFinalFetch;
+        Assert.assertTrue("Executed too many database retrievals: " + retrievalCountDuringFinalFetch, retrievalCountDuringFinalFetch <= 2);
+    }
+
+    public void testAdhocDeepFetch_OneToMany() throws SQLException, InterruptedException
+    {
+        if (OrderFinder.isFullCache())
+        {
+            logger.info("Skipping test - deep fetch test cases are only applicable to partial cache runtime configuration");
+            return;
+        }
+
+        final Operation op = OrderFinder.state().eq("In-Progress");
+        OrderList orderList = new OrderList(new ArrayList<Order>(OrderFinder.findMany(op)));
+        orderList.deepFetch(OrderFinder.items());
+
+        final Function<Order, Iterable<OrderItem>> getOrderItemsOfOrder = new Function<Order, Iterable<OrderItem>>()
+        {
+            @Override
+            public Iterable<OrderItem> valueOf(Order order)
+            {
+                return order.getItems();
+            }
+        };
+
+        final Predicate<OrderItem> orderItemStateEqualsInProgress = new Predicate<OrderItem>()
+        {
+            @Override
+            public boolean accept(OrderItem each)
+            {
+                return "In-Progress".equals(each.getState());
+            }
+        };
+
+        Assert.assertEquals(4, orderList.size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderItemsOfOrder).size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderItemsOfOrder).count(orderItemStateEqualsInProgress));
+        Assert.assertEquals(4, orderList.getItems().size());
+        Assert.assertEquals(4, orderList.getItems().asEcList().count(orderItemStateEqualsInProgress));
+
+        executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 55");
+        simulateOrderUpdateNotification(55, "state");
+
+        OrderList orderList2 = new OrderList(new ArrayList<Order>(OrderFinder.findMany(op)));
+        orderList2.deepFetch(OrderFinder.items());
+
+        Assert.assertEquals(5, orderList2.size());
+        Assert.assertEquals(6, orderList2.asEcList().flatCollect(getOrderItemsOfOrder).size());
+        Assert.assertEquals(5, orderList2.asEcList().flatCollect(getOrderItemsOfOrder).count(orderItemStateEqualsInProgress));
+        Assert.assertEquals(6, orderList2.getItems().size());
+        Assert.assertEquals(5, orderList2.getItems().asEcList().count(orderItemStateEqualsInProgress));
+
+        executeAndAssertSqlUpdate(1, "update APP.ORDER_ITEM set STATE = 'In-Progress' where ID = 6 and ORDER_ID = 55");
+        simulateOrderItemUpdateNotification(6, "state");
+
+        OrderList orderList3 = new OrderList(new ArrayList<Order>(OrderFinder.findMany(op)));
+        orderList3.deepFetch(OrderFinder.items());
+
+        Assert.assertEquals(5, orderList3.size());
+        Assert.assertEquals(6, orderList3.asEcList().flatCollect(getOrderItemsOfOrder).size());
+        Assert.assertEquals(6, orderList3.asEcList().flatCollect(getOrderItemsOfOrder).count(orderItemStateEqualsInProgress));
+        Assert.assertEquals(6, orderList3.getItems().size());
+        Assert.assertEquals(6, orderList3.getItems().asEcList().count(orderItemStateEqualsInProgress));
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, false, false, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, true, false, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_BypassCacheInPriorQuery_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, false, false, true, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_BypassCacheInPriorQuery_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, true, false, true, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_ChildUpdateAfterParentUpdate_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, false, true, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_ChildUpdateAfterParentUpdate_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, true, true, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_ChildUpdateAfterParentUpdate_ChildUpdatesObservedBeforeFinalDeepFetch_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, false, true, false, true);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenChildFetchAndCache_ChildUpdateAfterParentUpdate_ChildUpdatesObservedBeforeFinalDeepFetch_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE, true, true, false, true);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, false, false, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, true, false, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_BypassCacheInPriorQuery_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, false, false, true, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_BypassCacheInPriorQuery_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, true, false, true, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_ChildUpdateAfterParentUpdate_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, false, true, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_ChildUpdateAfterParentUpdate_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, true, true, false, false);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_ChildUpdateAfterParentUpdate_ChildUpdatesObservedBeforeFinalDeepFetch_SimplifiedOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, false, true, false, true);
+    }
+
+    public void testDeepFetch_OneToOne_NotificationBetweenParentFetchAndChildFetch_ChildUpdateAfterParentUpdate_ChildUpdatesObservedBeforeFinalDeepFetch_ComplexOp() throws Exception
+    {
+        runTestDeepFetchOneToOneTest(TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH, true, true, false, true);
+    }
+
+    private void runTestDeepFetchOneToOneTest(TimingTestCase timingTestCase, boolean forceComplexOp, boolean includeChildUpdateAfterParentUpdate, boolean bypassCacheInPriorQuery, boolean observeChildUpdatesBeforeFinalDeepFetch) throws SQLException, InterruptedException
+    {
+        if (OrderFinder.isFullCache())
+        {
+            logger.info("Skipping test - deep fetch test cases are only applicable to partial cache runtime configuration");
+            return;
+        }
+
+        forceComplexOp(forceComplexOp);
+
+        final Operation op = OrderFinder.state().eq("In-Progress");
+        OrderList orderList = OrderFinder.findMany(op);
+        orderList.deepFetch(harnessDeepFetchRelationship(OrderFinder.orderStatus(), timingTestCase));
+
+        final Function<Order, List<OrderStatus>> getOrderStatusOfOrder = new Function<Order, List<OrderStatus>>()
+        {
+            @Override
+            public List<OrderStatus> valueOf(Order order)
+            {
+                final OrderStatus orderStatus = order.getOrderStatus();
+                return orderStatus != null ? Collections.singletonList(orderStatus) : Collections.<OrderStatus>emptyList();
+            }
+        };
+
+        final Predicate<OrderStatus> orderStatusEqualsTen = new Predicate<OrderStatus>()
+        {
+            @Override
+            public boolean accept(OrderStatus each)
+            {
+                return each.getStatus() == 10;
+            }
+        };
+
+        allowAllFetches();
+
+        Assert.assertEquals(4, orderList.size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderStatusOfOrder).size());
+        Assert.assertEquals(4, orderList.getOrderStatus().size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+
+        // This update and notification gives the findMany a reason to have to hit the database, as it marks the cache as dirty.
+        executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 55");
+        simulateOrderUpdateNotification(55, "state");
+
+        makeFetchesWaitForSignal();
+
+        // Simulate a database update and notification message occurring during the deep fetch
+        Thread thread = new Thread(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                waitToStartUpdateThread(); // wait until the deep fetch retrieval has reached the right point
+
+                executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 56");
+                simulateOrderUpdateNotification(56, "state");
+
+                signalUpdateThreadDone(); // allow the deep fetch to complete
+            }
+        });
+        thread.start();
+
+        OrderList orderList2 = OrderFinder.findMany(op);
+        orderList2.setBypassCache(bypassCacheInPriorQuery);
+        orderList2.deepFetch(harnessDeepFetchRelationship(OrderFinder.orderStatus(), timingTestCase));
+
+        logger.info("Performing deep fetch retrieval with concurrent database update and notification of the parent table");
+
+        // The next call will resolve the deep fetch using the deep fetch strategy.
+        // The harnessed version of the deep fetch strategy coordinates with the update thread,
+        // to ensure the database updates are applied after the parent list is resolved but before the deep fetch was completed.
+        Assert.assertEquals(5, orderList2.size());
+
+        Assert.assertEquals(5, orderList2.asEcList().flatCollect(getOrderStatusOfOrder).size());
+        Assert.assertEquals(5, orderList2.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+
+        // Do not query orderList2.getOrderStatus() here or else it will re-fetch from database and that will mean the next deep fetch will hit the cache instead of the DB.
+        // The next part of the test relies on the fact that the deep fetch will hit the database to retrieve the updated Order 56, which triggers a re-fetch of OrderStatus.
+        // The test harness relies on that to happen so that it can co-ordinate the next database update to OrderStatus to happen at the same time.
+
+        thread.join();
+
+        if (includeChildUpdateAfterParentUpdate)
+        {
+            makeFetchesWaitForSignal();
+
+            // Simulate a database update and notification message occurring during the deep fetch
+            Thread thread2 = new Thread(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    waitToStartUpdateThread(); // wait until the deep fetch retrieval has reached the right point
+
+                    executeAndAssertSqlUpdate(1, "update APP.ORDER_STATUS set STATUS = 10 where ORDER_ID = 56");
+                    simulateOrderStatusUpdateNotification(56, "status");
+
+                    signalUpdateThreadDone(); // allow the deep fetch to complete
+                }
+            });
+            thread2.start();
+
+            OrderList orderList3 = OrderFinder.findMany(op);
+            orderList3.setBypassCache(bypassCacheInPriorQuery);
+            orderList3.deepFetch(harnessDeepFetchRelationship(OrderFinder.orderStatus(), timingTestCase));
+
+            logger.info("Performing a second deep fetch retrieval with concurrent database update and notification of the child table");
+
+            // The next call will resolve the deep fetch using the deep fetch strategy.
+            // The harnessed version of the deep fetch strategy coordinates with the update thread,
+            // to ensure the database updates are applied after the parent list is resolved but before the deep fetch was completed.
+            Assert.assertEquals(6, orderList3.size());
+
+            // The act of observing the related child objects causes them to be re-fetched from database because the cached results are stale.
+            // It therefore makes sense to test with and without this step, so that we also check that the next deep fetch does not retrieve stale results.
+            if (observeChildUpdatesBeforeFinalDeepFetch)
+            {
+                Assert.assertEquals(6, orderList3.asEcList().flatCollect(getOrderStatusOfOrder).size());
+                Assert.assertEquals(6, orderList3.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+
+                Assert.assertEquals(6, orderList3.getOrderStatus().size());
+                Assert.assertEquals(6, orderList3.getOrderStatus().asEcList().count(orderStatusEqualsTen));
+            }
+
+            thread2.join();
+        }
+
+        allowAllFetches();
+
+        // Should now reflect all updates to date as this is a brand new query
+        OrderList orderList4 = OrderFinder.findMany(op);
+        orderList4.deepFetch(harnessDeepFetchRelationship(OrderFinder.orderStatus(), timingTestCase));
+
+        logger.info("Performing final deep fetch retrieval");
+
+        Assert.assertEquals(6, orderList4.size());
+        Assert.assertEquals(6, orderList4.asEcList().collect(getOrderStatusOfOrder).size());
+        Assert.assertEquals(includeChildUpdateAfterParentUpdate ? 6 : 5, orderList4.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+
+        Assert.assertEquals(6, orderList4.getOrderStatus().size());
+        Assert.assertEquals(includeChildUpdateAfterParentUpdate ? 6 : 5, orderList4.getOrderStatus().asEcList().count(orderStatusEqualsTen));
+    }
+
+    public void testAdhocDeepFetch_OneToOne() throws SQLException, InterruptedException
+    {
+        if (OrderFinder.isFullCache())
+        {
+            logger.info("Skipping test - deep fetch test cases are only applicable to partial cache runtime configuration");
+            return;
+        }
+
+        final Operation op = OrderFinder.state().eq("In-Progress");
+        OrderList orderList = new OrderList(new ArrayList<Order>(OrderFinder.findMany(op)));
+        orderList.deepFetch(OrderFinder.orderStatus());
+
+        final Function<Order, List<OrderStatus>> getOrderStatusOfOrder = new Function<Order, List<OrderStatus>>()
+        {
+            @Override
+            public List<OrderStatus> valueOf(Order order)
+            {
+                final OrderStatus orderStatus = order.getOrderStatus();
+                return orderStatus != null ? Collections.singletonList(orderStatus) : Collections.<OrderStatus>emptyList();
+            }
+        };
+
+        final Predicate<OrderStatus> orderStatusEqualsTen = new Predicate<OrderStatus>()
+        {
+            @Override
+            public boolean accept(OrderStatus each)
+            {
+                return each.getStatus() == 10;
+            }
+        };
+
+        Assert.assertEquals(4, orderList.size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderStatusOfOrder).size());
+        Assert.assertEquals(4, orderList.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+        Assert.assertEquals(4, orderList.getOrderStatus().size());
+        Assert.assertEquals(4, orderList.getOrderStatus().asEcList().count(orderStatusEqualsTen));
+
+        executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 55");
+        executeAndAssertSqlUpdate(1, "update APP.ORDERS set STATE = 'In-Progress' where ORDER_ID = 56");
+        simulateOrderUpdateNotification(55, "state");
+        simulateOrderUpdateNotification(56, "state");
+
+        OrderList orderList2 = new OrderList(new ArrayList<Order>(OrderFinder.findMany(op)));
+        orderList2.deepFetch(OrderFinder.orderStatus());
+
+        Assert.assertEquals(6, orderList2.size());
+        Assert.assertEquals(6, orderList2.asEcList().flatCollect(getOrderStatusOfOrder).size());
+        Assert.assertEquals(5, orderList2.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+        Assert.assertEquals(6, orderList2.getOrderStatus().size());
+        Assert.assertEquals(5, orderList2.getOrderStatus().asEcList().count(orderStatusEqualsTen));
+
+        executeAndAssertSqlUpdate(1, "update APP.ORDER_STATUS set STATUS = 10 where ORDER_ID = 56");
+        simulateOrderStatusUpdateNotification(56, "status");
+
+        OrderList orderList3 = new OrderList(new ArrayList<Order>(OrderFinder.findMany(op)));
+        orderList3.deepFetch(OrderFinder.orderStatus());
+
+        Assert.assertEquals(6, orderList3.size());
+        Assert.assertEquals(6, orderList3.asEcList().flatCollect(getOrderStatusOfOrder).size());
+        Assert.assertEquals(6, orderList3.asEcList().flatCollect(getOrderStatusOfOrder).count(orderStatusEqualsTen));
+        Assert.assertEquals(6, orderList3.getOrderStatus().size());
+        Assert.assertEquals(6, orderList3.getOrderStatus().asEcList().count(orderStatusEqualsTen));
+    }
+
+    private void allowAllFetches()
+    {
+        signalDoneUpdating.release(999);
+    }
+
+    private void makeFetchesWaitForSignal()
+    {
+        signalWaitingForUpdate.drainPermits();
+        signalDoneUpdating.drainPermits();
+    }
+
+    private void executeAndAssertSqlUpdate(int expectedUpdateCount, String sql)
+    {
+        int updateCount = executeSqlUpdate(sql);
+        Assert.assertEquals(expectedUpdateCount, updateCount);
+    }
+
+    private int executeSqlUpdate(String sql)
+    {
+        final Connection conn = ConnectionManagerForTests.getInstance().getConnection();
+        try
+        {
+            try
+            {
+                logger.info(sql);
+                return conn.createStatement().executeUpdate(sql); // returns the updated number of rows
+            }
+            finally
+            {
+                conn.close();
+            }
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeException("Error executing SQL update as part of the test setup", e);
+        }
+    }
+
+    private void forceComplexOp(boolean forceComplexOp)
+    {
+        if (forceComplexOp)
+        {
+            DeepRelationshipUtility.setMaxSimplifiedIn(0);
+        }
+    }
+
+    private void simulateOrderUpdateNotification(int orderId, String... attributeNames)
+    {
+        final Order order = new Order();
+        order.setOrderId(orderId); // only the primary key is relevant for refresh / mark dirty
+
+        simulateUpdateNotification(OrderFinder.getFinderInstance(), order, attributeNames);
+    }
+
+    private void simulateOrderStatusUpdateNotification(int orderId, String... attributeNames)
+    {
+        final OrderStatus orderStatus = new OrderStatus();
+        orderStatus.setOrderId(orderId); // only the primary key is relevant for refresh / mark dirty
+
+        simulateUpdateNotification(OrderStatusFinder.getFinderInstance(), orderStatus, attributeNames);
+    }
+
+    private void simulateOrderItemUpdateNotification(int id, String... attributeNames)
+    {
+        final OrderItem orderItem = new OrderItem();
+        orderItem.setId(id); // only the primary key is relevant for refresh / mark dirty
+
+        simulateUpdateNotification(OrderItemFinder.getFinderInstance(), orderItem, attributeNames);
+    }
+
+    private void simulateUpdateNotification(RelatedFinder finder, MithraTransactionalObjectImpl businessObject, String... attributeNames)
+    {
+        // Simulate the invalidation of the partial cache caused by an incoming notification message.
+        // This logic is equivalent to PartialCacheMithraNotificationListener.onUpdate(), but without the complexity of
+        // having to ensure the object is already in the cache, in order to ensure the class update count gets incremented.
+
+        finder.getMithraObjectPortal().getCache().markDirty(businessObject.zGetCurrentData());
+        for (String attributeName : attributeNames)
+        {
+            finder.getAttributeByName(attributeName).incrementUpdateCount();
+        }
+        finder.getMithraObjectPortal().incrementClassUpdateCount();
+    }
+
+    private void resetDeepFetchRelationship(AbstractRelatedFinder relationshipFinder)
+    {
+        relationshipFinder.zSetDeepFetchStrategy(null);
+    }
+
+    private <R extends AbstractRelatedFinder & DeepRelationshipAttribute> R harnessDeepFetchRelationship(R relationshipFinder, TimingTestCase timingTestCase)
+    {
+        final DeepFetchStrategy originalStrategy = relationshipFinder.zGetDeepFetchStrategy();
+        final DeepFetchStrategy newStrategy;
+        if (originalStrategy instanceof SimpleToManyDeepFetchStrategy)
+        {
+            newStrategy = new HarnessedSimpleToManyDeepFetchStrategy(relationshipFinder.zGetMapper(), relationshipFinder.zGetOrderBy(), timingTestCase);
+        }
+        else if (originalStrategy instanceof SimpleToOneDeepFetchStrategy)
+        {
+            newStrategy = new HarnessedSimpleToOneDeepFetchStrategy(relationshipFinder.zGetMapper(), relationshipFinder.zGetOrderBy(), timingTestCase);
+        }
+        else
+        {
+            throw new IllegalStateException("Unsupported deep fetch strategy: " + originalStrategy);
+        }
+        relationshipFinder.zSetDeepFetchStrategy(newStrategy);
+        return relationshipFinder;
+    }
+
+    private void acquireOrTimeout(Semaphore semaphore)
+    {
+        try
+        {
+            if (!semaphore.tryAcquire(5L, TimeUnit.SECONDS))
+            {
+                throw new RuntimeException("Timed out waiting for semaphore");
+            }
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException("Interrupted" , e);
+        }
+    }
+
+    private void signalAndWaitForUpdate(String logLabel)
+    {
+        logger.info(logLabel + " starting wait");
+        signalWaitingForUpdate.release();
+        acquireOrTimeout(signalDoneUpdating);
+        logger.info(logLabel + " done waiting");
+    }
+
+    private void signalUpdateThreadDone()
+    {
+        logger.info("update thread done updating");
+        signalDoneUpdating.release();
+    }
+
+    private void waitToStartUpdateThread()
+    {
+        logger.info("update thread starting wait");
+        acquireOrTimeout(signalWaitingForUpdate);
+        logger.info("update thread done waiting");
+    }
+
+    private class HarnessedSimpleToManyDeepFetchStrategy extends SimpleToManyDeepFetchStrategy
+    {
+        private final TimingTestCase timingTestCase;
+
+        public HarnessedSimpleToManyDeepFetchStrategy(Mapper mapper, OrderBy orderBy, TimingTestCase timingTestCase)
+        {
+            super(mapper, orderBy);
+            this.timingTestCase = timingTestCase;
+        }
+
+        @Override
+        protected List getImmediateParentList(DeepFetchNode node)
+        {
+            final List immediateParentList = super.getImmediateParentList(node);
+            if (timingTestCase == TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH)
+            {
+                signalAndWaitForUpdate("getImmediateParentList");
+            }
+            return immediateParentList;
+        }
+
+        @Override
+        protected MithraList getResolvedListFromServer(boolean bypassCache, List immediateParentList, MithraList complexList, DeepFetchNode node)
+        {
+            final MithraList resolvedListFromServer = super.getResolvedListFromServer(bypassCache, immediateParentList, complexList, node);
+            if (timingTestCase == TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE)
+            {
+                signalAndWaitForUpdate("getResolvedListFromServer");
+            }
+            return resolvedListFromServer;
+        }
+    }
+
+    private class HarnessedSimpleToOneDeepFetchStrategy extends SimpleToOneDeepFetchStrategy
+    {
+        private final TimingTestCase timingTestCase;
+
+        public HarnessedSimpleToOneDeepFetchStrategy(Mapper mapper, OrderBy orderBy, TimingTestCase timingTestCase)
+        {
+            super(mapper, orderBy);
+            this.timingTestCase = timingTestCase;
+        }
+
+        @Override
+        protected List getImmediateParentList(DeepFetchNode node)
+        {
+            final List immediateParentList = super.getImmediateParentList(node);
+            if (timingTestCase == TimingTestCase.WAIT_BETWEEN_PARENT_FETCH_AND_CHILD_FETCH)
+            {
+                signalAndWaitForUpdate("getImmediateParentList");
+            }
+            return immediateParentList;
+        }
+
+        @Override
+        protected MithraList fetchSimplifiedJoinList(DeepFetchNode node, List parentList, boolean bypassCache)
+        {
+            final MithraList simplifiedJoinList = super.fetchSimplifiedJoinList(node, parentList, bypassCache);
+            if (simplifiedJoinList != null && timingTestCase == TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE)
+            {
+                signalAndWaitForUpdate("fetchSimplifiedJoinList");
+            }
+            return simplifiedJoinList;
+        }
+
+        @Override
+        protected void resolveComplexList(MithraList complexList)
+        {
+            super.resolveComplexList(complexList);
+            if (timingTestCase == TimingTestCase.WAIT_BETWEEN_CHILD_FETCH_AND_CHILD_CACHE)
+            {
+                signalAndWaitForUpdate("resolveComplexList");
+            }
+        }
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestRelationshipsNoInClause.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestRelationshipsNoInClause.java
@@ -37,7 +37,7 @@ public class TestRelationshipsNoInClause extends TestRelationships
     protected void tearDown() throws Exception
     {
         super.tearDown();
-        DeepRelationshipUtility.getInstance().setMaxSimplifiedIn(1000);
+        DeepRelationshipUtility.getInstance().resetMaxSimplifiedIn();
     }
 
     public void testMultiLevelSimplifiedInClause()

--- a/reladomo/src/test/resources/testdata/testNotificationDuringDeepFetch.txt
+++ b/reladomo/src/test/resources/testdata/testNotificationDuringDeepFetch.txt
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 Goldman Sachs.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+class com.gs.fw.common.mithra.test.domain.Order
+orderId,orderDate,userId,description,state,trackingId
+1,"2004-01-12 00:00:00.0", 1, "First order", "In-Progress", "123"
+2,"2004-02-12 00:00:00.0", 1, "Second order", "In-Progress", "124"
+3,"2004-03-12 00:00:00.0", 1, "Third order", "In-Progress", "125"
+4,"2004-04-12 00:00:00.0", 2, "Fourth order, different user", "In-Progress", "126"
+55,"2004-04-12 00:00:00.0", 3, "Order number five", "Gummed up", "127"
+56,"2004-04-12 00:00:00.0", 3, "Sixth order, different user", "Gummed up", "128"
+57,"2004-04-12 00:00:00.0", 3, "Seventh order, different user", "Gummed up", "129"
+
+class com.gs.fw.common.mithra.test.domain.OrderItem
+id,orderId,productId,quantity,originalPrice,discountPrice,state
+1,  1, 1, 20, 10.5, 10.5, "In-Progress"
+2,  2, 1, 20, 10.5, 10.5, "In-Progress"
+3,  2, 2, 20, 15.5, 10.0, "In-Progress"
+4,  2, 3, 20, 20.5, 15.0, "In-Progress"
+5, 55, 1, 20, 10.5, 10.5, "In-Progress"
+6, 55, 3, 20, 10.5, 10.5, "Gummed up"
+7, 56, 3, 20, 10.5, 10.5, "Gummed up"
+8, 56, 3, 20, 10.5, 10.5, "In-Progress"
+
+class com.gs.fw.common.mithra.test.domain.OrderStatus
+orderId,status,lastUser,lastUpdateTime, expectedDate
+1,10,"Fred","2004-01-12 00:00:00.0", "2005-01-01"
+2,10,"Fred","2004-01-12 00:00:00.0", "2005-01-01"
+3,10,"Fred","2004-01-12 00:00:00.0", "2005-01-01"
+4,10,"Fred","2004-01-12 00:00:00.0", "2005-01-01"
+55,10,"Fred","2004-01-12 00:00:00.0", "2005-01-01"
+56,99,"Fred","2004-01-12 00:00:00.0", "2005-01-01"
+57,10,"Fred","2004-01-12 00:00:00.0", "2005-01-01"


### PR DESCRIPTION
Hi,

I would be grateful if you could please review and consider accepting this bug fix, or let me know if you have any questions / feedback / changes required.

This fix is for a race condition in deep fetch which causes inconsistent related objects to be returned in certain cases when concurrent updates arrive via notification events.

This happens due to stale relationship query results in the partial cache that do not expire as they should, because the cache entries (CachedQuery objects) are stamped with update counters that were captured at the wrong time (i.e. after the database query completed, instead of before).

I've added test cases which reproduced the issue and made these pass. An earlier version of this fix has also been tested in a real world application for over a month without any repeat of the original issue, which had previously been happening on a daily basis.

The code changes should largely be self-explanatory but note that some additional classes had to be refactored slightly just to make it possible to inject a test harness around the deep fetch strategy under the test. I've also included a detailed step by step walkthrough below in case this helps to explain the mode of failure, since it was quite subtle and depended upon a chain of events. I also explained a bit more about the rationale behind the fix.

Looking forward to your feedback.

Thanks in advance,
Andrew

-------------------------

Detailed walkthrough of the issue and the approach to fix it:

As an example to provide some context, suppose we have a table A which has a relationship to table B. We retrieve Table A using findMany, and we request a deep fetch of the related objects in table B. Both tables are partial-cached in Reladomo. We have two Reladomo JVMs running concurrently which are linked via notification events. One of these JVMs is performing read queries including deep fetch, and the other JVM is performing writes to the same tables and sending corresponding notification events.

The race condition can occur if concurrent updates happen which bring additional parent objects (in table A) into scope of the finder query at the same time as the related objects (in table B) are being deep fetched from the database. The results of this database query on table B may not reflect the concurrent update to table A - in some cases because the query was optimised using an in-clause that was computed based on the original contents of table A, or because of a database join that got executed just prior to table A being updated. Note that the results of this deep fetch are actually correct, but the cache entry that is created for the related objects is tagged with the wrong update counter values and this causes the *next* deep fetch that happens later to return the wrong results.

Specifically, the deep fetch strategy submits these results for the related objects (of table B) into the partial cache as a CachedQuery which it incorrectly stamps with the latest update counter values that were captured *after* the query was executed. This causes the CachedQuery to report that it is not expired because the update counter incorporates the latest notification events, even though the cached results do not reflect the latest state of the database.

If the same finder query and deep fetch is subsequently executed again by the application at a later time, the additional parent objects (in table A) which came into scope will get returned by the findMany as expected, because it will requery table A in the database, but the corresponding related objects (in table B) will be missing from the deep fetch results because it will return the stale results from the cache.

The fix is relatively straightforward. The deep fetch strategy should capture the update counters before the related object query is executed, rather than afterwards. This will cause the CachedQuery to correctly detect that it has expired, so there will be no cache hit for the related objects query, and the deep fetch strategy will correctly re-retrieve the related objects from the database, using the correct join (or in-clause) based on the latest set of parent objects, and therefore the deep fetch will return the complete set of related objects as expected.

There is one other related type of race condition. In certain parts of the deep fetch logic we also need the related objects query to expire if the parent query has invalidated, since the change to the parent table may bring new objects into scope of the deep fetch, e.g. if the deep fetch strategy executed the related objects query as a 'simplified' query that uses an in-clause instead of a join. The fix for this issue is to enhance CachedQuery to be able to merge the update counters of the parent query with the update counters of the related objects query, taking account of the fact that these are two different operations which depend on different tables and hence depend on different update counter holders. This fix is also included as part of this pull request.
