### PR TITLE
Correct limit row count for MariaDB and Postgres.

### DIFF
--- a/dco/qiangqiang_tong.dco
+++ b/dco/qiangqiang_tong.dco
@@ -1,0 +1,9 @@
+1) I, Qiangqiang Tong, certify that all work committed with the commit message
+"covered by: qiangqiang_tong.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2020-07-02 to 9999-01-01.

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/MariaDatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/MariaDatabaseType.java
@@ -112,7 +112,7 @@ public class MariaDatabaseType extends AbstractDatabaseType
         String result = super.getSelect(columns, query, groupBy, isInTransaction, rowCount);
         if (rowCount > 0)
         {
-            result += " LIMIT "+rowCount + 1;
+            result += " LIMIT "+ (rowCount + 1);
         }
         if (isInTransaction)
         {

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/PostgresDatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/PostgresDatabaseType.java
@@ -113,7 +113,7 @@ public class PostgresDatabaseType extends AbstractDatabaseType
         String result = super.getSelect(columns, query, groupBy, isInTransaction, rowCount);
         if (rowCount > 0)
         {
-            result += " LIMIT "+rowCount + 1;
+            result += " LIMIT "+ (rowCount + 1);
         }
         if (isInTransaction)
         {


### PR DESCRIPTION
This to correct row count limitation for MariaDB and Postgres.

As of now, row count will be limited to 1001, in case rowCount = 100.