### PR TITLE
Implement equals and hashCode() on Timestamp-part and Date-part Calculators.

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/ByteAttribute.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/ByteAttribute.java
@@ -537,7 +537,7 @@ public abstract class ByteAttribute<T> extends PrimitiveNumericAttribute<T, Byte
     @Override
     public ByteAttribute absoluteValue()
     {
-        throw new UnsupportedOperationException("absoluteValue is not implemented for ShortAttribute");
+        throw new UnsupportedOperationException("absoluteValue is not implemented for ByteAttribute");
     }
 
     public NumericAttribute zDispatchAddTo(NumericAttribute firstAddend)

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/DateDayOfMonthCalculator.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/DateDayOfMonthCalculator.java
@@ -63,12 +63,29 @@ public class DateDayOfMonthCalculator extends SingleAttributeNumericCalculator<D
     @Override
     public void appendToString(ToStringContext toStringContext)
     {
-        toStringContext.append(attribute.getAttributeName()).append(".dayOfMonth");
+        toStringContext.append("dayOfMonth(");
+        this.attribute.zAppendToString(toStringContext);
+        toStringContext.append(")");
     }
 
     @Override
     public Operation optimizedIntegerEq(int value, CalculatedIntegerAttribute intAttribute)
     {
         return new IntegerEqOperation(intAttribute, value);
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        if (obj.getClass().equals(this.getClass()))
+        {
+            return this.attribute.equals(((DateDayOfMonthCalculator)obj).attribute);
+        }
+        return false;
+    }
+
+    public int hashCode()
+    {
+        return 0x23456781 ^ this.attribute.hashCode();
     }
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/DateMonthCalculator.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/DateMonthCalculator.java
@@ -63,12 +63,29 @@ public class DateMonthCalculator extends SingleAttributeNumericCalculator<DateAt
     @Override
     public void appendToString(ToStringContext toStringContext)
     {
-        toStringContext.append(attribute.getAttributeName()).append(".month");
+        toStringContext.append("month(");
+        this.attribute.zAppendToString(toStringContext);
+        toStringContext.append(")");
     }
 
     @Override
     public Operation optimizedIntegerEq(int value, CalculatedIntegerAttribute intAttribute)
     {
         return new IntegerEqOperation(intAttribute, value);
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        if (obj.getClass().equals(this.getClass()))
+        {
+            return this.attribute.equals(((DateMonthCalculator)obj).attribute);
+        }
+        return false;
+    }
+
+    public int hashCode()
+    {
+        return 0x34567812 ^ this.attribute.hashCode();
     }
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/DateYearCalculator.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/DateYearCalculator.java
@@ -62,7 +62,9 @@ public class DateYearCalculator extends SingleAttributeNumericCalculator<DateAtt
     @Override
     public void appendToString(ToStringContext toStringContext)
     {
-        toStringContext.append(attribute.getAttributeName()).append(".year");
+        toStringContext.append("year(");
+        this.attribute.zAppendToString(toStringContext);
+        toStringContext.append(")");
     }
 
     @Override
@@ -72,5 +74,20 @@ public class DateYearCalculator extends SingleAttributeNumericCalculator<DateAtt
         LocalDate localDateAfter = new LocalDate().withYear(value + 1).withDayOfMonth(1).withMonthOfYear(1);
 
         return this.attribute.greaterThanEquals(localDateBefore.toDate()).and(attribute.lessThan(localDateAfter.toDate()));
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        if (obj.getClass().equals(this.getClass()))
+        {
+            return this.attribute.equals(((DateYearCalculator)obj).attribute);
+        }
+        return false;
+    }
+
+    public int hashCode()
+    {
+        return 0x45678123 ^ this.attribute.hashCode();
     }
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/TimestampDayOfMonthCalculator.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/TimestampDayOfMonthCalculator.java
@@ -75,12 +75,29 @@ public class TimestampDayOfMonthCalculator extends SingleAttributeNumericCalcula
     @Override
     public void appendToString(ToStringContext toStringContext)
     {
-        toStringContext.append(attribute.getAttributeName()).append(".dayOfMonth");
+        toStringContext.append("dayOfMonth(");
+        this.attribute.zAppendToString(toStringContext);
+        toStringContext.append(")");
     }
 
     @Override
     public Operation optimizedIntegerEq(int value, CalculatedIntegerAttribute intAttribute)
     {
         return new IntegerEqOperation(intAttribute, value);
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        if (obj.getClass().equals(this.getClass()))
+        {
+            return this.attribute.equals(((TimestampDayOfMonthCalculator)obj).attribute);
+        }
+        return false;
+    }
+
+    public int hashCode()
+    {
+        return 0x56781234 ^ this.attribute.hashCode();
     }
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/TimestampMonthCalculator.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/TimestampMonthCalculator.java
@@ -75,12 +75,29 @@ public class TimestampMonthCalculator extends SingleAttributeNumericCalculator<T
     @Override
     public void appendToString(ToStringContext toStringContext)
     {
-        toStringContext.append(attribute.getAttributeName()).append(".month");
+        toStringContext.append("month(");
+        this.attribute.zAppendToString(toStringContext);
+        toStringContext.append(")");
     }
 
     @Override
     public Operation optimizedIntegerEq(int value, CalculatedIntegerAttribute intAttribute)
     {
         return new IntegerEqOperation(intAttribute, value);
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        if (obj.getClass().equals(this.getClass()))
+        {
+            return this.attribute.equals(((TimestampMonthCalculator)obj).attribute);
+        }
+        return false;
+    }
+
+    public int hashCode()
+    {
+        return 0x67812345 ^ this.attribute.hashCode();
     }
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/TimestampYearCalculator.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/attribute/calculator/arithmeticCalculator/TimestampYearCalculator.java
@@ -18,6 +18,7 @@ package com.gs.fw.common.mithra.attribute.calculator.arithmeticCalculator;
 
 import com.gs.fw.common.mithra.attribute.CalculatedIntegerAttribute;
 import com.gs.fw.common.mithra.attribute.TimestampAttribute;
+import com.gs.fw.common.mithra.attribute.calculator.AbstractAbsoluteValueCalculator;
 import com.gs.fw.common.mithra.finder.Operation;
 import com.gs.fw.common.mithra.finder.SqlQuery;
 import com.gs.fw.common.mithra.finder.ToStringContext;
@@ -77,7 +78,9 @@ public class TimestampYearCalculator extends SingleAttributeNumericCalculator<Ti
     @Override
     public void appendToString(ToStringContext toStringContext)
     {
-        toStringContext.append(attribute.getAttributeName()).append(".year");
+        toStringContext.append("year(");
+        this.attribute.zAppendToString(toStringContext);
+        toStringContext.append(")");
     }
 
     @Override
@@ -91,5 +94,20 @@ public class TimestampYearCalculator extends SingleAttributeNumericCalculator<Ti
         Timestamp timestampAfter = new Timestamp(dateAfter.getMillis());
 
         return this.attribute.greaterThanEquals(timestampBefore).and(attribute.lessThan(timestampAfter));
+    }
+
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        if (obj.getClass().equals(this.getClass()))
+        {
+            return this.attribute.equals(((TimestampYearCalculator)obj).attribute);
+        }
+        return false;
+    }
+
+    public int hashCode()
+    {
+        return 0x78123456 ^ this.attribute.hashCode();
     }
 }

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestAtomicOperationsToString.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestAtomicOperationsToString.java
@@ -19,7 +19,6 @@ package com.gs.fw.common.mithra.test;
 
 import com.gs.fw.common.mithra.finder.Operation;
 import com.gs.fw.common.mithra.finder.bytearray.ByteArraySet;
-import com.gs.fw.common.mithra.test.domain.DatedAllTypes;
 import com.gs.fw.common.mithra.test.domain.DatedAllTypesFinder;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.eclipse.collections.impl.set.mutable.primitive.ByteHashSet;
@@ -34,12 +33,9 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.Format;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
-
 
 public class TestAtomicOperationsToString extends MithraTestAbstract
 {
@@ -540,6 +536,38 @@ public class TestAtomicOperationsToString extends MithraTestAbstract
 
         Operation bigDecimalValueEquals = DatedAllTypesFinder.bigDecimalValue().notIn(gscDoubleSet);
         assertEquals("DatedAllTypes.bigDecimalValue not in [7.70000, 8.80000]", bigDecimalValueEquals.toString());
+    }
+
+    public void testAbsoluteValueOperation()
+    {
+        Operation intValueEquals = DatedAllTypesFinder.intValue().absoluteValue().eq(4);
+        assertEquals("abs( DatedAllTypes.intValue ) = 4", intValueEquals.toString());
+
+        Operation longValueEquals = DatedAllTypesFinder.longValue().absoluteValue().eq(5L);
+        assertEquals("abs( DatedAllTypes.longValue ) = 5", longValueEquals.toString());
+
+        Operation floatValueEquals = DatedAllTypesFinder.floatValue().absoluteValue().eq((float)6.6);
+        assertEquals("abs( DatedAllTypes.floatValue ) = 6.6", floatValueEquals.toString());
+
+        Operation doubleValueEquals = DatedAllTypesFinder.doubleValue().absoluteValue().eq(7.7);
+        assertEquals("abs( DatedAllTypes.doubleValue ) = 7.7", doubleValueEquals.toString());
+    }
+
+    public void testDatePartOperation()
+    {
+        Operation dateYearValueEquals  = DatedAllTypesFinder.dateValue().year().notEq(1999);
+        Operation dateMonthValueEquals = DatedAllTypesFinder.dateValue().month().notEq(12);
+        Operation dateDayValueEquals   = DatedAllTypesFinder.dateValue().dayOfMonth().notEq(31);
+        assertEquals("year( DatedAllTypes.dateValue ) != 1999", dateYearValueEquals.toString());
+        assertEquals("month( DatedAllTypes.dateValue ) != 12", dateMonthValueEquals.toString());
+        assertEquals("dayOfMonth( DatedAllTypes.dateValue ) != 31", dateDayValueEquals.toString());
+
+        Operation timestampYearValueEquals  = DatedAllTypesFinder.timestampValue().year().notEq(1999);
+        Operation timestampMonthValueEquals = DatedAllTypesFinder.timestampValue().month().notEq(12);
+        Operation timestampDayValueEquals   = DatedAllTypesFinder.timestampValue().dayOfMonth().notEq(31);
+        assertEquals("year( DatedAllTypes.timestampValue ) != 1999", timestampYearValueEquals.toString());
+        assertEquals("month( DatedAllTypes.timestampValue ) != 12", timestampMonthValueEquals.toString());
+        assertEquals("dayOfMonth( DatedAllTypes.timestampValue ) != 31", timestampDayValueEquals.toString());
     }
 
     private void assertEqualsEither(String expected1, String expected2, String actual)


### PR DESCRIPTION
I noticed that identical operations that use timestamp parts weren't being considered equal.

```
Operation operation1 = DatedAllTypesFinder.timestampValue().month().eq(1);
Operation operation2 = DatedAllTypesFinder.timestampValue().month().eq(1);
boolean isEqual = operation1.equals(operation2);
System.out.println("isEqual = " + isEqual);
```

This change makes isEqual go from false to true. I'd be happy to add tests for this but I didn't find an obvious place.

While I was looking at this, I noticed that the toString() representation of these attributes looks like:
```
timestampValue .month = 1
```
Since these are derived attributes, I was kind of expecting a representation like:
```
month(timestampValue) = 1
```
Thoughts?