### PR TITLE
Update WildcardParser.java

### DIFF
--- a/reladomo/src/main/java/com/gs/fw/common/mithra/util/WildcardParser.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/util/WildcardParser.java
@@ -220,6 +220,7 @@ public class WildcardParser implements Serializable
             if (inEscapeSequence)
             {
                 inEscapeSequence = false;
+                last = c;
                 continue;
             }
 
@@ -328,6 +329,7 @@ public class WildcardParser implements Serializable
             if (inEscapeSequence)
             {
                 inEscapeSequence = false;
+                last = c;
                 continue;
             }
 
@@ -405,6 +407,7 @@ public class WildcardParser implements Serializable
             if (inEscapeSequence)
             {
                 inEscapeSequence = false;
+                last = c;
                 continue;
             }
 


### PR DESCRIPTION
In cases where the pattern is like "\'[1-9\']\'[1-9\']", the generated Pattern is "^[1-9]'\[1-9]$" instead of "^[1-9][1-9]$" because the last is not updated while continuing in the isInEscape branch.
