### PR TITLE
Add Snowflake support: introduce SnowflakeDatabaseType

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1391,6 +1391,11 @@
                     driver="org.mariadb.jdbc.Driver"
                     url="jdbc:mariadb://${maria_hostname}:${maria_port}/${maria_databaseName}" schema="${maria_schemaName}"
                           includeTables="ALL_TYPES, IDENTITY_TABLE, PRODUCT, TEST_BALANCE_NO_ACMAP, ORDERS, ORDER_ITEM, BIG_ORDERS"/>
+        <mkdir dir ="${root}/reladomogenutil/target/reverse/snowflake"/>
+        <reladomo-gen-xml userName="${snowflake_user}" password="${snowflake_password}" databaseType="snowflake" outputDir="${root}/reladomogenutil/target/reverse/snowflake"
+                    driver="net.snowflake.client.jdbc.SnowflakeDriver"
+                    url="jdbc:snowflake://${snowflake_account}.snowflakecomputing.com/?db=${snowflake_database}&amp;schema=${snowflake_schema}&amp;warehouse=${snowflake_warehouse}" 
+                    schema="${snowflake_schema}" includeTables="ALL_TYPES, IDENTITY_TABLE, PRODUCT, TEST_BALANCE_NO_ACMAP, ORDERS, ORDER_ITEM, BIG_ORDERS"/>
     </target>
 
     <!-- ************************** /reladomogenutil **********************************-->
@@ -1910,6 +1915,7 @@
             <exec-test-suite mithraxmlconfig="MithraMsSqlTestConfig.xml" testclass="com.gs.fw.common.mithra.test.MithraMsSqlTestSuite" heap="onheap"/>
             <exec-test-suite mithraxmlconfig="MithraSybaseTestConfig.xml" testclass="com.gs.fw.common.mithra.test.MithraSybaseTestSuite" heap="onheap"/>
             <exec-test-suite mithraxmlconfig="MithraMariaTestConfig.xml" testclass="com.gs.fw.common.mithra.test.MithraMariaTestSuite" heap="onheap"/>
+            <exec-test-suite mithraxmlconfig="MithraSnowflakeTestConfig.xml" testclass="com.gs.fw.common.mithra.test.MithraSnowflakeTestSuite" heap="onheap"/>
         </parallel>
     </target>
 
@@ -1924,6 +1930,7 @@
                 <include name="TEST-*MithraPostgresTestConfig.xml"/>
                 <include name="TEST-*MithraOracleTestConfig.xml"/>
                 <include name="TEST-*MithraMariaTestConfig.xml"/>
+                <include name="TEST-*MithraSnowflakeTestConfig.xml"/>
             </fileset>
             <report format="frames" todir="${root}/reladomo/target/junit-report-vendor-test"/>
         </junitreport>

--- a/dco/tianyi_cao.dco
+++ b/dco/tianyi_cao.dco
@@ -1,0 +1,9 @@
+1) I, Tianyi Cao, certify that all work committed with the commit message
+"covered by: tianyi_cao.dco" is my original work and I own the copyright
+to this work. I agree to contribute this code under the Apache 2.0 license.
+
+2) I understand and agree all contribution including all personal
+information I submit with it is maintained indefinitely and may be
+redistributed consistent with the open source license(s) involved.
+
+This certification is effective for all code contributed from 2025-11-26 to 9999-01-01.

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionManager.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/connectionmanager/XAConnectionManager.java
@@ -162,6 +162,10 @@ public class XAConnectionManager extends AbstractConnectionManager
             {
                 this.databaseType = MariaDatabaseType.getInstance();
             }
+            else if (name.indexOf(".snowflake.") >= 0)
+            {
+                this.databaseType = SnowflakeDatabaseType.getInstance();
+            }
         }
     }
 

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraAbstractDatabaseObject.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/database/MithraAbstractDatabaseObject.java
@@ -660,6 +660,7 @@ public abstract class MithraAbstractDatabaseObject
     {
         Connection con = null;
         Statement stm = null;
+        DatabaseType dt = this.getDatabaseTypeGenericSource(genericSource);
         try
         {
             con = this.getConnectionForTempWriteGenericSource(genericSource, isForQuery);
@@ -673,7 +674,10 @@ public abstract class MithraAbstractDatabaseObject
             {
                 this.getSqlLogger().debug("connection:"+System.identityHashCode(con)+" creating temp table index with: " + indexSql);
             }
-            stm.executeUpdate(indexSql);
+            if (dt.shouldCreateTestIndexes()) 
+            {
+                stm.executeUpdate(indexSql);   
+            }
             if (this.getSqlLogger().isDebugEnabled())
             {
                 this.getSqlLogger().debug("creating temp index with: " + indexSql);
@@ -2668,13 +2672,16 @@ public abstract class MithraAbstractDatabaseObject
         dt.appendTestTableCreationPostamble(sb);
         executeSqlStatementGenericSource(sb.toString(), source);
 
-        if (this.getFinder().getAsOfAttributes() != null)
+        if (dt.shouldCreateTestIndexes()) 
         {
-            this.createUniqueIndexForTestTable(source);
-        }
-        else
-        {
-            this.createPrimaryKeyIndexForTestTable(source);
+            if (this.getFinder().getAsOfAttributes() != null)
+            {
+                this.createUniqueIndexForTestTable(source);
+            }
+            else
+            {
+                this.createPrimaryKeyIndexForTestTable(source);
+            }
         }
     }
 

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/DatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/DatabaseType.java
@@ -295,4 +295,9 @@ public interface DatabaseType extends CommonDatabaseType
     public boolean canCombineOptimisticWithBatchUpdates();
 
     boolean varBinaryHasLength();
+
+    default boolean shouldCreateTestIndexes() 
+    { 
+        return true; 
+    }
 }

--- a/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/SnowflakeDatabaseType.java
+++ b/reladomo/src/main/java/com/gs/fw/common/mithra/databasetype/SnowflakeDatabaseType.java
@@ -1,0 +1,626 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.gs.fw.common.mithra.databasetype;
+
+import com.gs.fw.common.mithra.MithraObjectPortal;
+import com.gs.fw.common.mithra.attribute.Attribute;
+import com.gs.fw.common.mithra.attribute.update.AttributeUpdateWrapper;
+import com.gs.fw.common.mithra.finder.SqlQuery;
+import com.gs.fw.common.mithra.tempobject.TupleTempContext;
+import com.gs.fw.common.mithra.util.MithraFastList;
+import com.gs.fw.common.mithra.util.TableColumnInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.*;
+
+// No row-level locks for standard Snowflake tables.
+// Future: add optional optimistic checks (version or compare-on-change) in UPDATE...FROM join.
+public class SnowflakeDatabaseType extends AbstractDatabaseType
+{
+    private static final Logger logger = LoggerFactory.getLogger(SnowflakeDatabaseType.class.getName());
+    private static final String DUPLICATE_ERROR_CODE = "23505";
+    private static final char[] SNOWFLAKE_SQL_META_CHARS = { '%', '_', '\\' };
+    private static final SnowflakeDatabaseType instance = new SnowflakeDatabaseType();
+    private static final Map<String, String> sqlToJavaTypes;
+
+    private String tempSchema = null;
+    private String database = null;
+
+    enum OptimisticMode 
+    {
+        NONE, VERSION_COLUMN, COMPARE_COLUMNS
+    }
+
+    public void setDatabase(String database)
+    {
+        this.database = database;
+    }
+    // private OptimisticMode optimisticMode = OptimisticMode.NONE; // future use
+
+    public static Logger getLogger()
+    {
+        return logger;
+    }
+
+    static
+    {
+        // https://docs.snowflake.com/en/developer-guide/udf-stored-procedure-data-type-mapping
+        Map<String, String> m = new HashMap<String, String>();
+
+        m.put("decimal", "BigDecimal");
+        m.put("numeric", "BigDecimal");
+
+        m.put("float", "Double");
+        m.put("double", "Double");
+        m.put("double precision", "Double");
+        m.put("boolean", "Boolean");
+
+        m.put("varchar", "String");
+        m.put("string", "String");
+        m.put("text", "String");
+        m.put("binary", "byte[]");
+
+        m.put("date", "Date");
+        m.put("time", "Time");
+        m.put("timestamp", "Timestamp");
+        m.put("timestamp_ntz", "Timestamp");
+        m.put("timestamp_ltz", "Timestamp");
+        m.put("timestamp_tz", "Timestamp");
+
+        sqlToJavaTypes = Collections.unmodifiableMap(m);
+    }
+
+    public static SnowflakeDatabaseType getInstance()
+    {
+        return instance;
+    }
+
+    protected SnowflakeDatabaseType()
+    {
+    }
+
+    @Override
+    public int getMaxPreparedStatementBatchCount(int parametersPerStatement)
+    {
+        return 100;
+    }
+
+    public boolean hasTopQuery()
+    {
+        return true;
+    }
+
+    public void setTempSchema(String tempSchema)
+    {
+        this.tempSchema = tempSchema;
+    }
+
+    @Override
+    public String convertDateToString(java.util.Date date)
+    {
+        return super.convertDateToString(date);
+    }
+
+    // --- SELECT ---
+
+    @Override
+    public String getSelect(String columns, SqlQuery query, String groupBy, boolean isInTransaction, int rowCount)
+    {
+        String result = super.getSelect(columns, query, groupBy, isInTransaction, rowCount);
+        if (rowCount > 0)
+        {
+            result += " LIMIT " + (rowCount + 1);
+        }
+        // Intentionally no "FOR UPDATE" for Snowflake Standard Tables.
+        return result;
+    }
+
+    @Override
+    public String getSelect(String columns, String fromClause, String whereClause, boolean lock)
+    {
+        // Ignore "lock" for Snowflake Standard Tables.
+        return super.getSelect(columns, fromClause, whereClause, lock);
+    }
+
+    /**
+     * Snowflake-specific tweak for aggregate queries.
+     *
+     * Background:
+     * - For integer inputs Snowflake's VAR_POP / VARIANCE / AVG return a FIXED/NUMBER(p,s)
+     *   value with a non-zero scale (e.g. 2.000000).
+     * - Mithra aggregate attributes for var/variance/stddev/avg over byte/int/long
+     *   are mapped to primitive types and populated via ResultSet.getInt()/getLong()/getDouble().
+     * - The Snowflake JDBC driver does not coerce scaled FIXED values to int/long and throws
+     *   "Cannot convert value in the driver from type: FIXED(..) to type: Int/Long".
+     *
+     * To keep the Snowflake adapter compatible with existing schemas and tests, we cast the
+     * aggregate inputs to DOUBLE so that VAR_POP / VARIANCE / AVG also return DOUBLE, which
+     * the driver can safely read through the existing Mithra code paths.
+     */
+    @Override
+    public String getSelectForAggregatedData(SqlQuery query, List aggregateAttributes, List groupByAttributes)
+    {
+        String sql = super.getSelectForAggregatedData(query, aggregateAttributes, groupByAttributes);
+
+        sql = sql.replaceAll(
+            "(?i)\\bvar_pop\\s*\\(([^)]+)\\)",
+            "VAR_POP(CAST($1 AS DOUBLE))");
+
+        sql = sql.replaceAll(
+            "(?i)\\bvariance\\s*\\(([^)]+)\\)",
+            "VARIANCE(CAST($1 AS DOUBLE))");
+
+        sql = sql.replaceAll(
+            "(?i)\\bavg\\s*\\(([^)]+)\\)",
+            "CAST(AVG(CAST($1 AS DOUBLE)) AS DOUBLE)");
+
+        return sql;
+    }
+
+    // --- DELETE ---
+
+    @Override
+    public String getDelete(SqlQuery query, int rowCount)
+    {
+        // Snowflake does NOT support "DELETE ... LIMIT n" directly.
+        // We fall back to deleting by WHERE only when rowCount>0 is requested.
+        StringBuilder sb = new StringBuilder("delete from ").append(query.getFromClauseAsString());
+        String where = query.getWhereClauseAsString(0);
+        if (where != null && where.trim().length() > 0)
+        {
+            sb.append(" where ").append(where);
+        }
+        // If you need limited delete, implement a PK-driven EXISTS with subselect
+        // LIMIT.
+        return sb.toString();
+    }
+
+    // --- locking / tx / retries ---
+
+    @Override
+    public int zGetTxLevel()
+    {
+        return Connection.TRANSACTION_READ_COMMITTED;
+    }
+
+    @Override
+    public String getPerStatementLock(boolean lock)
+    {
+        return "";
+    }
+
+    @Override
+    protected boolean hasRowLevelLocking()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean dropTableAllowedInTransaction()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean isRetriableWithoutRecursion(SQLException sqlException)
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean isTimedOutWithoutRecursion(SQLException exception)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean violatesUniqueIndexWithoutRecursion(SQLException exception)
+    {
+        return DUPLICATE_ERROR_CODE.equals(exception.getSQLState());
+    }
+
+    // --- temp tables ---
+
+    @Override
+    public String getSqlPrefixForNonSharedTempTableCreation(String nominalTableName)
+    {
+        return "create temporary table " + nominalTableName + getSqlPostfixForNonSharedTempTableCreation();
+    }
+
+    @Override
+    public String getSqlPostfixForNonSharedTempTableCreation()
+    {
+        return "";
+    }
+
+    @Override
+    public String getSqlPostfixForSharedTempTableCreation()
+    {
+        return "";
+    }
+
+    @Override
+    public String appendNonSharedTempTableCreatePreamble(StringBuilder sb, String tempTableName)
+    {
+        sb.append("CREATE TEMPORARY TABLE ").append(tempTableName);
+        return tempTableName;
+    }
+
+    @Override
+    public String appendSharedTempTableCreatePreamble(StringBuilder sb, String tempTableName)
+    {
+        if (tempSchema != null)
+        {
+            tempTableName = tempSchema + "." + tempTableName;
+        }
+        sb.append("CREATE TABLE ").append(tempTableName);
+        return tempTableName;
+    }
+
+    @Override
+    public boolean indexRequiresSchemaName()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean nonSharedTempTablesAreDroppedAutomatically()
+    {
+        return true;
+    }
+
+    // --- SQL data types ---
+
+    @Override
+    public String getSqlDataTypeForBoolean()
+    {
+        return "boolean";
+    }
+
+    // default to NTZ; adjust to LTZ/TZ if needed in schema generation
+    @Override
+    public String getSqlDataTypeForTimestamp()
+    {
+        return "timestamp_ntz";
+    }
+
+    @Override
+    public String getSqlDataTypeForTime()
+    {
+        return "time";
+    }
+
+    @Override
+    public String getSqlDataTypeForTinyInt()
+    {
+        return "number(3,0)";
+    }
+
+    @Override
+    public String getSqlDataTypeForVarBinary()
+    {
+        return "binary";
+    }
+
+    @Override
+    public String getSqlDataTypeForByte()
+    {
+        return "number(3,0)";
+    }
+
+    @Override
+    public String getSqlDataTypeForChar()
+    {
+        return "varchar(1)";
+    }
+
+    @Override
+    public String getSqlDataTypeForDateTime()
+    {
+        return "date";
+    }
+
+    @Override
+    public String getSqlDataTypeForDouble()
+    {
+        return "double";
+    }
+
+    @Override
+    public String getSqlDataTypeForFloat()
+    {
+        return "float";
+    }
+
+    @Override
+    public String getSqlDataTypeForInt()
+    {
+        return "number(10,0)";
+    }
+
+    @Override
+    public String getSqlDataTypeForLong()
+    {
+        return "number(38,0)";
+    }
+
+    @Override
+    public String getSqlDataTypeForShortJava()
+    {
+        return "number(5,0)";
+    }
+
+    @Override
+    public String getSqlDataTypeForString()
+    {
+        return "varchar";
+    }
+
+    @Override
+    public String getSqlDataTypeForBigDecimal()
+    {
+        return "number";
+    }
+
+    // --- schema / metadata ---
+
+    @Override
+    public String getCreateSchema(String schema)
+    {
+        if (schema == null || schema.trim().length() == 0)
+        {
+            return null;
+        }
+        StringBuilder sql = new StringBuilder();
+        if (database != null) {
+            sql.append("USE DATABASE ").append(database).append("; ");
+        }
+        sql.append("CREATE SCHEMA IF NOT EXISTS ").append(schema).append("; ");
+        sql.append("USE SCHEMA ").append(schema);
+        return sql.toString();
+    }
+
+    @Override
+    public TableColumnInfo getTableColumnInfo(Connection connection, String schema, String table) throws SQLException
+    {
+        return super.getTableColumnInfo(connection, schema, table);
+    }
+
+    /**
+     * Maps a Snowflake SQL type to a Java type.
+     *
+     * <p>
+     * Design principles:
+     * <ul>
+     * <li>Always return boxed types (Integer, Long, Double, Boolean, Character)
+     * because Snowflake columns are nullable by default.</li>
+     * <li>Use BigDecimal for any fractional numbers or very large integers to avoid
+     * precision loss.</li>
+     * <li>Semi-structured types (VARIANT, ARRAY, OBJECT, MAP, GEOGRAPHY) are
+     * represented as String (JSON text) by default.</li>
+     * </ul>
+     *
+     * <p>
+     * Other mappings (DATE, TIME, TIMESTAMP, etc.) are resolved from
+     * {@code sqlToJavaTypes}. Unknown types default to String.
+     */
+    @Override
+    public String getJavaTypeFromSql(String sql, Integer precision, Integer decimal)
+    {
+        if (sql == null)
+            return null;
+
+        String key = sql.trim().toLowerCase(Locale.ROOT);
+        int idx = key.indexOf('(');
+        if (idx >= 0)
+        {
+            key = key.substring(0, idx).trim();
+        }
+
+        String mapped = sqlToJavaTypes.get(key);
+        if (mapped != null && !"BigDecimal".equals(mapped))
+        {
+            return mapped;
+        }
+
+        if ("number".equals(key) || "numeric".equals(key) || "decimal".equals(key))
+        {
+            if (decimal != null && decimal > 0)
+            {
+                return "BigDecimal";
+            }
+            if (precision != null)
+            {
+                if (precision <= 9)
+                    return "Integer";
+                if (precision <= 18)
+                    return "Long";
+            }
+            return "BigDecimal";
+        }
+
+        if ("float".equals(key) || "double".equals(key) || "double precision".equals(key))
+        {
+            return "Double";
+        }
+
+        if ("char".equals(key) || "character".equals(key) || "nchar".equals(key))
+        {
+            if (precision != null && precision == 1)
+            {
+                return "Character";
+            }
+            return "String";
+        }
+
+        if ("variant".equals(key) || "array".equals(key) || "object".equals(key) || "map".equals(key)
+                || "geography".equals(key))
+        {
+            return "String";
+        }
+
+        return (mapped != null) ? mapped : "String";
+    }
+
+    // --- multi-insert / identity ---
+
+    @Override
+    protected boolean hasSelectUnionMultiInsert()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean hasValuesMultiInsert()
+    {
+        return false;
+    }
+
+    @Override
+    public int getMultiInsertBatchSize(int columnsToInsert)
+    {
+        return 1000;
+    }
+
+    @Override
+    public String getLastIdentitySql(String tableName)
+    {
+        return null;
+    }
+
+    // --- stats / conversion / like ---
+
+    @Override
+    public String getUpdateTableStatisticsSql(String tableName)
+    {
+        return null;
+    }
+
+    @Override
+    protected char[] getLikeMetaChars()
+    {
+        return SNOWFLAKE_SQL_META_CHARS;
+    }
+
+    @Override
+    public String getConversionFunctionIntegerToString(String expression)
+    {
+        return "cast(" + expression + " as varchar)";
+    }
+
+    @Override
+    public String getConversionFunctionStringToInteger(String expression)
+    {
+        return "cast(" + expression + " as number(38,0))";
+    }
+
+    // --- date/timestamp extract ---
+
+    @Override
+    public String getSqlExpressionForDateYear(String columnName)
+    {
+        return "EXTRACT(YEAR FROM " + columnName + ")";
+    }
+
+    @Override
+    public String getSqlExpressionForDateMonth(String columnName)
+    {
+        return "EXTRACT(MONTH FROM " + columnName + ")";
+    }
+
+    @Override
+    public String getSqlExpressionForDateDayOfMonth(String columnName)
+    {
+        return "EXTRACT(DAY FROM " + columnName + ")";
+    }
+
+    @Override
+    protected String getSqlExpressionForTimestampYearWithConversion(String columnName, int conversion,
+            TimeZone dbTimeZone)
+    {
+        return "EXTRACT(YEAR FROM " + columnName + ")";
+    }
+
+    @Override
+    protected String getSqlExpressionForTimestampMonthWithConversion(String columnName, int conversion,
+            TimeZone dbTimeZone)
+    {
+        return "EXTRACT(MONTH FROM " + columnName + ")";
+    }
+
+    @Override
+    protected String getSqlExpressionForTimestampDayOfMonthWithConversion(String columnName, int conversion,
+            TimeZone dbTimeZone)
+    {
+        return "EXTRACT(DAY FROM " + columnName + ")";
+    }
+
+    // --- UPDATE ... FROM join ---
+
+    @Override
+    public void setMultiUpdateViaJoinQuery(Object source, List updates, Attribute[] prototypeArray,
+            MithraFastList<Attribute> nullAttributes, int pkAttributeCount, TupleTempContext tempContext,
+            MithraObjectPortal mithraObjectPortal, String fullyQualifiedTableNameGenericSource, StringBuilder builder)
+    {
+        this.startUpdateViaJoinQuery(fullyQualifiedTableNameGenericSource, builder);
+        builder.append(" t0 set ");
+        for (int i = 0; i < updates.size(); i++)
+        {
+            AttributeUpdateWrapper wrapper = (AttributeUpdateWrapper) updates.get(i);
+            if (i > 0)
+            {
+                builder.append(", ");
+            }
+            builder.append(wrapper.getSetAttributeSql());
+        }
+        builder.append(" from ");
+        this.appendTempTableRightSideJoin(source, prototypeArray, nullAttributes, pkAttributeCount, tempContext,
+                mithraObjectPortal, builder);
+    }
+
+    @Override
+    public void setBatchUpdateViaJoinQuery(Object source, List updates, Attribute[] prototypeArray,
+            MithraFastList<Attribute> nullAttributes, int pkAttributeCount, TupleTempContext tempContext,
+            MithraObjectPortal mithraObjectPortal, String fullyQualifiedTableNameGenericSource, StringBuilder builder)
+    {
+        this.startUpdateViaJoinQuery(fullyQualifiedTableNameGenericSource, builder);
+        builder.append(" t0 set ");
+        for (int i = 0; i < updates.size(); i++)
+        {
+            AttributeUpdateWrapper wrapper = (AttributeUpdateWrapper) updates.get(i);
+            if (i > 0)
+            {
+                builder.append(", ");
+            }
+            builder.append(wrapper.getAttribute().getColumnName()).append(" = t1.c");
+            builder.append(pkAttributeCount + i);
+        }
+        builder.append(" from ");
+        appendTempTableRightSideJoin(source, prototypeArray, nullAttributes, pkAttributeCount, tempContext,
+                mithraObjectPortal, builder);
+    }
+
+    @Override
+    public boolean shouldCreateTestIndexes()
+    {
+        return false;
+    }
+
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraSnowflakeTestAbstract.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraSnowflakeTestAbstract.java
@@ -1,0 +1,165 @@
+
+/*
+ Copyright 2016 Goldman Sachs.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+ package com.gs.fw.common.mithra.test;
+
+import com.gs.fw.common.mithra.MithraList;
+import com.gs.fw.common.mithra.databasetype.DatabaseType;
+import com.gs.fw.common.mithra.databasetype.SnowflakeDatabaseType;
+import com.gs.fw.common.mithra.finder.Operation;
+import com.gs.fw.common.mithra.test.domain.AllTypes;
+import com.gs.fw.common.mithra.test.domain.AllTypesList;
+import com.gs.fw.common.mithra.test.domain.Order;
+import com.gs.fw.common.mithra.test.domain.OrderList;
+import com.gs.fw.common.mithra.util.Time;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+
+public abstract class MithraSnowflakeTestAbstract extends MithraTestAbstract
+{
+    private MithraTestResource mithraTestResource;
+    private String testDataFileName = "testdata/vendor/mithraSnowflakeTestData.txt";
+
+    public void setTestDataFileName(String testDataFileName)
+    {
+        this.testDataFileName = testDataFileName;
+    }
+
+    public String getTestDataFileName()
+    {
+        return testDataFileName;
+    }
+
+    protected void setUp() throws Exception
+    {
+        setMithraTestObjectToResultSetComparator(new AllTypesResultSetComparator());
+        mithraTestResource = new MithraTestResource("MithraSnowflakeTestConfig.xml", SnowflakeDatabaseType.getInstance());
+        mithraTestResource.setRestrictedClassList(getRestrictedClassList());
+
+        SnowflakeTestConnectionManager connectionManager = SnowflakeTestConnectionManager.getInstance();
+        connectionManager.setDefaultSource("mithra_qa");
+        connectionManager.setDatabaseTimeZone(this.getDatabaseTimeZone());
+        
+        mithraTestResource.createSingleDatabase(connectionManager, "mithra_qa", getTestDataFileName());
+        mithraTestResource.setTestConnectionsOnTearDown(true);
+        mithraTestResource.setUp();
+    }
+
+    @Override
+    public Connection getConnection()
+    {
+        return SnowflakeTestConnectionManager.getInstance().getConnection();
+    }
+
+    protected DatabaseType getDatabaseType()
+    {
+        return this.mithraTestResource.getDatabaseType();
+    }
+
+    protected OrderList createOrderList(int count, int initialOrderId)
+    {
+        OrderList orderList = new OrderList();
+        for (int i = 0; i < count; i++)
+        {
+            Order order = new Order();
+            order.setOrderId(initialOrderId + i);
+            order.setUserId(999);
+            orderList.add(order);
+        }
+        return orderList;
+    }
+
+    protected void validateMithraResult(Operation op, String sql)
+    {
+        validateMithraResult(op, sql, 1);
+    }
+
+    protected void validateMithraResult(Operation op, String sql, int minSize)
+    {
+        this.validateMithraResult(new AllTypesList(op), sql, minSize);
+    }
+
+    protected void validateMithraResult(MithraList<?> list, String sql, int minSize)
+    {
+    try
+        {
+            list.setBypassCache(true);
+            Connection con = SnowflakeTestConnectionManager.getInstance().getConnection();
+            PreparedStatement ps = con.prepareStatement(sql);
+            this.genericRetrievalTest(ps, list, con, minSize);
+        }
+        catch(SQLException e)
+        {
+            getLogger().error("SQLException on MithraSnowflakeTestAbstract.validateMithraResult()", e);
+            throw new RuntimeException("SQLException ", e);
+        }
+    }
+
+    protected AllTypes createNewAllTypes(int id, boolean withNullablesNull)
+    {
+        AllTypes allTypesObj = new AllTypes();
+        Date date = new Date();
+        Timestamp timestamp = new Timestamp(date.getTime());
+        byte[] newData = new byte[5];
+        newData[0] = toByte(0xAA);
+        newData[1] = toByte(0xBB);
+        newData[2] = toByte(0x99);
+        newData[3] = toByte(0x11);
+        newData[4] = 0;
+
+        if(withNullablesNull)
+        {
+            allTypesObj.setNullablePrimitiveAttributesToNull();
+        }
+        else
+        {
+            allTypesObj.setNullableByteValue((byte)100);
+            allTypesObj.setNullableShortValue((short) 30000);
+            allTypesObj.setNullableCharValue('a');
+            allTypesObj.setNullableIntValue(2000000000);
+            allTypesObj.setNullableLongValue(9000000000000000000L);
+            allTypesObj.setNullableFloatValue(100.99f);
+            allTypesObj.setNullableDoubleValue(100.99998888777);
+            allTypesObj.setNullableDateValue(date);
+            allTypesObj.setNullableTimeValue(Time.withMillis(1, 2, 3, 4));
+            allTypesObj.setNullableTimestampValue(timestamp);
+            allTypesObj.setNullableStringValue("This is a test");
+            allTypesObj.setNullableByteArrayValue(newData);
+
+        }
+        allTypesObj.setId(id);
+        allTypesObj.setBooleanValue(true);
+        allTypesObj.setByteValue((byte)100);
+        allTypesObj.setShortValue((short) 30000);
+        allTypesObj.setCharValue('a');
+        allTypesObj.setIntValue(2000000000);
+        allTypesObj.setLongValue(9000000000000000000L);
+        allTypesObj.setFloatValue(100.99f);
+        allTypesObj.setDoubleValue(100.99998888777);
+        allTypesObj.setDateValue(date);
+        allTypesObj.setTimeValue(Time.withMillis(1, 2, 3, 4));
+        allTypesObj.setTimestampValue(timestamp);
+        allTypesObj.setStringValue("This is a test");
+        allTypesObj.setByteArrayValue(newData);
+
+        return allTypesObj;
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraSnowflakeTestSuite.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/MithraSnowflakeTestSuite.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Goldman Sachs.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.gs.fw.common.mithra.test;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class MithraSnowflakeTestSuite extends TestSuite
+{
+    public static Test suite()
+    {
+        TestSuite suite = new TestSuite();
+        suite.addTestSuite(TestSnowflakeGeneralTestCases.class);
+        return suite;
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/SnowflakeTestConnectionManager.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/SnowflakeTestConnectionManager.java
@@ -1,0 +1,75 @@
+
+/*
+ Copyright 2016 Goldman Sachs.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+package com.gs.fw.common.mithra.test;
+
+import com.gs.fw.common.mithra.bulkloader.BulkLoader;
+import com.gs.fw.common.mithra.bulkloader.BulkLoaderException;
+import com.gs.fw.common.mithra.connectionmanager.XAConnectionManager;
+import com.gs.fw.common.mithra.databasetype.SnowflakeDatabaseType;
+
+public class SnowflakeTestConnectionManager extends VendorTestConnectionManager
+{
+    private final static SnowflakeTestConnectionManager instance = new SnowflakeTestConnectionManager();
+
+    public static SnowflakeTestConnectionManager getInstance()
+    {
+        return instance;
+    }
+
+    protected SnowflakeTestConnectionManager()
+    {
+        readCredentials();
+        connectionManager = new XAConnectionManager();
+        connectionManager.setDriverClassName("net.snowflake.client.jdbc.SnowflakeDriver");
+        // jdbc:snowflake://<account>.snowflakecomputing.com/
+        connectionManager.setJdbcConnectionString("jdbc:snowflake://" 
+            + getCredential("snowflake_account") 
+            + ".snowflakecomputing.com/?db=" + getCredential("snowflake_database") 
+            + "&schema=" + getCredential("snowflake_schema") 
+            + "&warehouse=" + getCredential("snowflake_warehouse" ) 
+            + "&CLIENT_TIMESTAMP_TYPE_MAPPING=TIMESTAMP_NTZ"
+            + "&JDBC_TREAT_TIMESTAMP_NTZ_AS_UTC=false"); 
+        connectionManager.setJdbcUser(getCredential("snowflake_user"));
+        connectionManager.setJdbcPassword(getCredential("snowflake_password"));
+        connectionManager.setDefaultSchemaName(getCredential("snowflake_schema"));
+        connectionManager.setPoolName(getCredential("snowflake_account") + ":" + 
+            getCredential("snowflake_database") + ":" + getCredential("snowflake_schema") + " connection pool");
+        connectionManager.setInitialSize(1);
+        connectionManager.setPoolSize(100);
+        connectionManager.setUseStatementPooling(true);
+        connectionManager.initialisePool();
+
+        SnowflakeDatabaseType.getInstance().setTempSchema(getCredential("snowflake_schema")); 
+        this.setDatabaseType(SnowflakeDatabaseType.getInstance());
+    }
+
+    public BulkLoader createBulkLoader() throws BulkLoaderException
+    {
+        return null; // Implement Snowflake bulk loading if needed
+    }
+
+    public String getDatabaseIdentifier()
+    {
+        return getCredential("snowflake_account") + getCredential("snowflake_database");
+    }
+
+    public String getSchema()
+    {
+        return getCredential("snowflake_schema");
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestSnowflakeGeneralTestCases.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestSnowflakeGeneralTestCases.java
@@ -1,0 +1,503 @@
+
+/*
+ Copyright 2016 Goldman Sachs.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+package com.gs.fw.common.mithra.test;
+
+import java.sql.Timestamp;
+import java.text.ParseException;
+
+import org.eclipse.collections.impl.set.mutable.UnifiedSet;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
+
+import com.gs.fw.common.mithra.MithraManagerProvider;
+import com.gs.fw.common.mithra.finder.Operation;
+import com.gs.fw.common.mithra.test.aggregate.TestStandardDeviation;
+import com.gs.fw.common.mithra.test.aggregate.TestVariance;
+import com.gs.fw.common.mithra.test.domain.AllTypesFinder;
+import com.gs.fw.common.mithra.test.domain.AllTypesList;
+import com.gs.fw.common.mithra.test.domain.Order;
+import com.gs.fw.common.mithra.test.domain.OrderFinder;
+import com.gs.fw.common.mithra.test.domain.OrderList;
+import com.gs.fw.common.mithra.util.DoWhileProcedure;
+import com.gs.fw.common.mithra.util.TempTableNamer;
+
+public class TestSnowflakeGeneralTestCases extends MithraSnowflakeTestAbstract
+{
+    // Snowflake's STDDEV_POP over integer-like columns (after the CAST to DOUBLE in
+    // the adapter) differs from the reference value by ~2e-7. Use a slightly looser
+    // bound for those Snowflake-specific stddev_pop tests.
+    private static final double DELTA = 0.000001;
+
+    public void tearDown() throws Exception
+    {
+        MithraManagerProvider.getMithraManager().setTransactionTimeout(60);
+        super.tearDown();
+    }
+
+    public void testRollback()
+    {
+        new CommonVendorTestCases().testRollback();
+    }
+
+    public void testTimestampGranularity() throws Exception
+    {
+        new CommonVendorTestCases().testTimestampGranularity();
+    }
+
+    public void testOptimisticLocking() throws Exception
+    {
+        new CommonVendorTestCases().testOptimisticLocking();
+    }
+
+    public void testTimeTransactionalBasicTime()
+    {
+        new TestTimeTransactional().testBasicTime();
+    }
+
+    public void testTimeTransactionalToString()
+    {
+        new TestTimeTransactional().testToString();
+    }
+
+    public void testTimeTransactionalInsert()
+    {
+        new TestTimeTransactional().testInsert();
+    }
+
+    public void testTimeTransactionalDelete()
+    {
+        new TestTimeTransactional().testDelete();
+    }
+
+    public void testTimeTransactionalUpdate()
+    {
+        new TestTimeTransactional().testUpdate();
+    }
+
+    public void testTimeTransactionalNullTime()
+    {
+        new TestTimeTransactional().testNullTime();
+    }
+
+    public void testTimeNonTransactionalBasicTime()
+    {
+        new TestTimeNonTransactional().testBasicTime();
+    }
+
+    public void testTimeNonTransactionalToString()
+    {
+        new TestTimeNonTransactional().testToString();
+    }
+
+    public void testTimeNonTransactionalNullTime()
+    {
+        new TestTimeNonTransactional().testNullTime();
+    }
+
+    public void testTimeDatedTransactionalBasicTime()
+    {
+        new TestTimeDatedTransactional().testBasicTime();
+    }
+
+    public void testTimeDatedTransactionalUpdateTime()
+    {
+        new TestTimeDatedTransactional().testUpdate();
+    }
+
+    public void testTimeDatedTransactionalToString()
+    {
+        new TestTimeDatedTransactional().testToString();
+    }
+
+    public void testTimeDatedTransactionalInsert()
+    {
+        new TestTimeDatedTransactional().testInsert();
+    }
+
+    public void testTimeDatedTransactionalTerminate()
+    {
+        new TestTimeDatedTransactional().testTerminate();
+    }
+
+    public void testTimeDatedTransactionalNullTime()
+    {
+        new TestTimeDatedTransactional().testNullTime();
+    }
+
+    public void testTimeDatedNonTransactionalBasicTime()
+    {
+        new TestTimeDatedNonTransactional().testBasicTime();
+    }
+
+    public void testTimeDatedNonTransactionalToString()
+    {
+        new TestTimeDatedNonTransactional().testToString();
+    }
+
+    public void testTimeDatedNonTransactionalNullTime()
+    {
+        new TestTimeDatedNonTransactional().testNullTime();
+    }
+
+    public void testTimeBitemporalTransactionalBasicTime() 
+    {
+        new TestTimeBitemporalTransactional().testBasicTime();
+    }
+
+    public void testTimeBitemporalTransactionalToString() 
+    {
+        new TestTimeBitemporalTransactional().testToString();
+    }
+
+    public void testTimeBitemporalTransactionalInsert() 
+    {
+        new TestTimeBitemporalTransactional().testInsert();
+    }
+
+    public void testTimeBitemporalTransactionalTerminate() 
+    {
+        new TestTimeBitemporalTransactional().testTerminate();
+    }
+
+    public void testTimeBitemporalTransactionalUpdate() 
+    {
+        new TestTimeBitemporalTransactional().testUpdate();
+    }
+
+    public void testTimeBitemporalTransactionalUpdateUntil() 
+    {
+        new TestTimeBitemporalTransactional().testUpdateUntil();
+    }
+
+    public void testTimeBitemporalTransactionalInsertUntil() 
+    {
+        new TestTimeBitemporalTransactional().testInsertUntil();
+    }
+
+    // Can't terminateUntil on an in-memory object
+    // public void testTimeBitemporalTransactionalTerminateUntil() 
+    // {
+    //     new TestTimeBitemporalTransactional().testTerminateUntil();
+    // }
+
+    public void testTimeBitemporalTransactionalNullTime() 
+    {
+        new TestTimeBitemporalTransactional().testNullTime();
+    }
+
+    public void testStandardDeviationDouble() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevDouble();
+    }
+
+    public void testStandardDeviationPopDouble() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevPopDouble();
+    }
+
+    public void testStandardDeviationInt() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevInt();
+    }
+
+    public void testStandardDeviationPopInt() throws ParseException
+    {
+        new TestStandardDeviation(DELTA).testStdDevPopInt();
+    }
+
+    public void testStandardDeviationLong() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevLong();
+    }
+
+    public void testStandardDeviationPopLong() throws ParseException
+    {
+        new TestStandardDeviation(DELTA).testStdDevPopLong();
+    }
+
+    public void testStandardDeviationShort() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevShort();
+    }
+
+    public void testStandardDeviationPopShort() throws ParseException
+    {
+        new TestStandardDeviation(DELTA).testStdDevPopShort();
+    }
+
+    public void testStandardDeviationByte() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevByte();
+    }
+
+    public void testStandardDeviationPopByte() throws ParseException
+    {
+        new TestStandardDeviation(DELTA).testStdDevPopByte();
+    }
+
+    public void testStandardDeviationFloat() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevFloat();
+    }
+
+    public void testStandardDeviationPopFloat() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevPopFloat();
+    }
+
+    public void testStandardDeviationBigDecimal() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevBigDecimal();
+    }
+
+    public void testStandardDeviationPopBigDecimal() throws ParseException
+    {
+        new TestStandardDeviation().testStdDevPopBigDecimal();
+    }
+
+    public void testVarianceDouble() throws ParseException
+    {
+        new TestVariance().testVarianceDouble();
+    }
+
+    public void testVariancePopDouble() throws ParseException
+    {
+        new TestVariance().testVariancePopDouble();
+    }
+
+    public void testVarianceInt() throws ParseException
+    {
+        new TestVariance().testVarianceInt();
+    }
+
+    public void testVariancePopInt() throws ParseException
+    {
+        new TestVariance().testVariancePopInt();
+    }
+
+    public void testVarianceLong() throws ParseException
+    {
+        new TestVariance().testVarianceLong();
+    }
+
+    public void testVariancePopLong() throws ParseException
+    {
+        new TestVariance().testVariancePopLong();
+    }
+
+    public void testVarianceShort() throws ParseException
+    {
+        new TestVariance().testVarianceShort();
+    }
+
+    public void testVariancePopShort() throws ParseException
+    {
+        new TestVariance().testVariancePopShort();
+    }
+
+    public void testVarianceByte() throws ParseException
+    {
+        new TestVariance().testVarianceByte();
+    }
+
+    public void testVariancePopByte() throws ParseException
+    {
+        new TestVariance().testVariancePopByte();
+    }
+
+    public void testVarianceFloat() throws ParseException
+    {
+        new TestVariance().testVarianceFloat();
+    }
+
+    public void testVariancePopFloat() throws ParseException
+    {
+        new TestVariance().testVariancePopFloat();
+    }
+
+    public void testVarianceBigDecimal() throws ParseException
+    {
+        new TestVariance().testVarianceBigDecimal();
+    }
+
+    public void testVariancePopBigDecimal() throws ParseException
+    {
+        new TestVariance().testVariancePopBigDecimal();
+    }
+
+    public void testTimestampMonthDayOfMonthTuplesTiny()
+    {
+        new TestYearMonthTuple().testTimestampTupleMonthDayOfMonthTinySet();
+    }
+
+    public void testTimestampYearDayOfMonthTuplesTiny()
+    {
+        new TestYearMonthTuple().testTimestampTupleYearDayOfMonthTinySet();
+    }
+
+    public void testTimestampYearMonthTuplesTiny()
+    {
+        new TestYearMonthTuple().testTimestampTupleYearMonthTinySet();
+    }
+
+    public void testDateMonthDayOfMonthTuplesTiny()
+    {
+        new TestYearMonthTuple().testTupleMonthDayOfMonthTinySet();
+    }
+
+    public void testDateYearDayOfMonthTuplesTiny()
+    {
+        new TestYearMonthTuple().testTupleYearDayOfMonthTinySet();
+    }
+
+    public void testDateYearMonthTuplesTiny()
+    {
+        new TestYearMonthTuple().testTupleYearMonthTinySet();
+    }
+
+    public void testDateYearMonthTuplesValueOf()
+    {
+        new TestYearMonthTuple().testValueOf();
+    }
+
+    public void testDateYearMonthTuples()
+    {
+        new TestYearMonthTuple().testTupleYearMonthSet();
+    }
+
+    public void testTimestampTuplesValueOf()
+    {
+        new TestYearMonthTuple().testTimestampValueOf();
+    }
+
+    public void testTimestampYearMonthTuples()
+    {
+        new TestYearMonthTuple().testTimestampTupleYearMonthSet();
+    }
+
+    public void testStringLikeEscapes()
+    {
+        new TestStringLike().testStringLikeEscapes();
+    }
+
+    public void testTimeTuples()
+    {
+        new TestTimeTuple().testTupleSet();
+    }
+
+    public void testBasicRetrievalMaxObjectsToRetrieve()
+    {
+        new TestBasicRetrieval().testMaxObjectsToRetrieve();
+    }
+
+    public void testRetrieveLimitedRows()
+    {
+        int id = 9876;
+        Operation op = AllTypesFinder.id().greaterThanEquals(id);
+        AllTypesList list = new AllTypesList(op);
+        list.setMaxObjectsToRetrieve(5);
+        list.setOrderBy(AllTypesFinder.id().ascendingOrderBy());
+        assertEquals(5, list.size());
+    }
+
+    public void testTempTableNamer()
+    {
+        String first = TempTableNamer.getNextTempTableName();
+        for (int i = 0; i < 1000000; i++)
+        {
+            assertFalse(first.equals(TempTableNamer.getNextTempTableName()));
+        }
+        UnifiedSet<String> set = new UnifiedSet<>(10000);
+        for (int i = 0; i < 10000; i++)
+        {
+            String s = TempTableNamer.getNextTempTableName();
+            assertFalse(set.contains(s));
+            set.add(s);
+        }
+    }
+
+    public void testSybaseTopQuery()
+    {
+        OrderList list = new OrderList(OrderFinder.orderId().lessThan(5));
+        list.setMaxObjectsToRetrieve(1);
+        assertEquals(1, list.size());
+    }
+
+    public void testSybaseTopQueryWithCursor()
+    {
+        OrderList list = new OrderList(OrderFinder.orderId().lessThan(5));
+        list.setMaxObjectsToRetrieve(1);
+        final int[] count = new int[1];
+        list.forEachWithCursor(new DoWhileProcedure()
+        {
+            public boolean execute(Object object)
+            {
+                Order o = (Order) object;
+                count[0]++;
+                return true;
+            }
+        });
+        assertEquals(1, count[0]);
+    }
+
+    public void testMod()
+    {
+        TestCalculated testCalculated = new TestCalculated();
+        testCalculated.testMod();
+    }
+
+    public void testReadInNewYork() throws ParseException
+    {
+        Timestamp ts = new Timestamp(timestampFormat.parse("2008-04-01 00:00:00.0").getTime());
+        Order newOrder = new Order();
+        newOrder.setOrderId(999);
+        newOrder.setState("Some state");
+        newOrder.setTrackingId("Tracking Id");
+        newOrder.setUserId(1);
+        newOrder.setOrderDate(ts);
+
+        newOrder.insert();
+        OrderFinder.clearQueryCache();
+        Order order = OrderFinder.findOne(OrderFinder.orderId().eq(999));
+        assertEquals(ts, order.getOrderDate());
+    }
+
+    public void testDeleteAllInBatches()
+    {
+        OrderList list = createOrderList(5000, 1000);
+        list.bulkInsertAll();
+        OrderList firstList = new OrderList(OrderFinder.userId().eq(999));
+        firstList.deleteAllInBatches(500);
+        validateMithraResult(OrderFinder.userId().eq(999), "SELECT * FROM ORDERS WHERE USER_ID = 999", 0);
+    }
+
+    public void testDeleteAllInBatchesWithIn()
+    {
+        OrderList list = createOrderList(5000, 1000);
+        list.bulkInsertAll();
+
+        IntHashSet ids = new IntHashSet(5000);
+        for (int i = 1000; i < (6000); i++)
+        {
+            ids.add(i);
+        }
+
+        OrderList firstList = new OrderList(OrderFinder.orderId().in(ids));
+        firstList.deleteAllInBatches(500);
+        validateMithraResult(OrderFinder.userId().eq(999), "SELECT * FROM ORDERS WHERE USER_ID = 999", 0);
+    }
+}

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTimeDatedNonTransactional.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTimeDatedNonTransactional.java
@@ -53,6 +53,8 @@ public class TestTimeDatedNonTransactional extends MithraTestAbstract
     public void testToString()
     {
         AlarmDatedNonTransactionalList alarmList = new AlarmDatedNonTransactionalList(AlarmDatedNonTransactionalFinder.all());
+        alarmList.addOrderBy(AlarmDatedNonTransactionalFinder.id().ascendingOrderBy());
+
         assertEquals("10:30:59.011", alarmList.get(0).getTime().toString());
         assertEquals("03:11:23.000", alarmList.get(1).getTime().toString());
         assertEquals("14:59:10.043", alarmList.get(2).getTime().toString());

--- a/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTimeDatedTransactional.java
+++ b/reladomo/src/test/java/com/gs/fw/common/mithra/test/TestTimeDatedTransactional.java
@@ -61,6 +61,8 @@ public class TestTimeDatedTransactional extends MithraTestAbstract
     public void testToString()
     {
         AlarmDatedTransactionalList alarmList = new AlarmDatedTransactionalList(AlarmDatedTransactionalFinder.all());
+        alarmList.addOrderBy(AlarmDatedTransactionalFinder.id().ascendingOrderBy());
+
         assertEquals("10:30:59.011", alarmList.get(0).getTime().toString());
         assertEquals("03:11:23.000", alarmList.get(1).getTime().toString());
         assertEquals("14:59:10.043", alarmList.get(2).getTime().toString());

--- a/reladomo/src/test/resources/MithraSnowflakeTestConfig.xml
+++ b/reladomo/src/test/resources/MithraSnowflakeTestConfig.xml
@@ -1,0 +1,37 @@
+
+<!--
+  Copyright 2016 Goldman Sachs.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
+<MithraRuntime>
+    <ConnectionManager className="com.gs.fw.common.mithra.test.SnowflakeTestConnectionManager" schema="PUBLIC">
+        <MithraTemporaryObjectConfiguration className="com.gs.fw.common.mithra.test.domain.OrderDriver"/>
+        <Schema name="public">
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.Product" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.TimestampConversion" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.Order" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.TestEodAcctIfPnl" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.alarm.Alarm" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.alarm.AlarmNonTransactional" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.alarm.AlarmDatedTransactional" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.alarm.AlarmDatedNonTransactional" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.alarm.AlarmBitemporalTransactional" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.SaleAggregateData" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.ParaDesk" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.AllTypes" cacheType="partial"/>
+            <MithraObjectConfiguration className="com.gs.fw.common.mithra.test.domain.alarm.AlarmCategory" cacheType="partial"/>
+        </Schema>
+    </ConnectionManager>
+</MithraRuntime>

--- a/reladomo/src/test/resources/credentials.properties
+++ b/reladomo/src/test/resources/credentials.properties
@@ -61,3 +61,10 @@ db2_port=unpublished
 db2_schemaName=unpublished
 db2_databaseName=unpublished
 db2_tablespace=unpublished
+
+snowflake_account=unpublished
+snowflake_user=unpublished
+snowflake_password=unpublished
+snowflake_database=unpublished
+snowflake_schema=unpublished
+snowflake_warehouse=unpublished

--- a/reladomo/src/test/resources/testdata/vendor/mithraSnowflakeTestData.txt
+++ b/reladomo/src/test/resources/testdata/vendor/mithraSnowflakeTestData.txt
@@ -1,0 +1,120 @@
+/*
+Copyright 2016 Goldman Sachs.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+class com.gs.fw.common.mithra.test.domain.Product
+productId, productCode,productDescription,manufacturerId,dailyProductionRate
+1, "AA", "Product 1", 1, 100.10
+2, "AA", "Product 2", 1, 120.20
+3, "AB", "Product 3", 2, 300
+4, "AB", "Product 4", 3, 400
+
+class com.gs.fw.common.mithra.test.domain.alarm.Alarm
+id, time, description
+1, "10:30:59.011", "alarm 1"
+2, "03:11:23.000", "alarm 2"
+3, "14:59:10.043", "alarm 3"
+
+class com.gs.fw.common.mithra.test.domain.alarm.AlarmNonTransactional
+id, time, description
+1, "10:30:59.011", "alarm 1"
+2, "03:11:23.000", "alarm 2"
+3, "14:59:10.043", "alarm 3"
+4, null, "null alarm"
+
+class com.gs.fw.common.mithra.test.domain.alarm.AlarmDatedTransactional
+id, time, description, processingDateFrom,processingDateTo
+1, "10:30:59.011", "alarm 1", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+2, "03:11:23.000", "alarm 2", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+3, "14:59:10.043", "alarm 3", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+
+class com.gs.fw.common.mithra.test.domain.alarm.AlarmDatedNonTransactional
+id, time, description, processingDateFrom,processingDateTo
+1, "10:30:59.011", "alarm 1", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+2, "03:11:23.000", "alarm 2", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+3, "14:59:10.043", "alarm 3", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+4, null, "null alarm", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+
+class com.gs.fw.common.mithra.test.domain.alarm.AlarmBitemporalTransactional
+id, time, description, businessDateFrom, businessDateTo, processingDateFrom,processingDateTo
+1, "10:30:59.011", "alarm 1", "2012-01-01 23:59:00.0", "9999-12-01 23:59:00.0", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+2, "03:11:23.000", "alarm 2", "2012-01-01 23:59:00.0", "9999-12-01 23:59:00.0", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+3, "14:59:10.043", "alarm 3", "2012-01-01 23:59:00.0", "9999-12-01 23:59:00.0", "2000-01-01 00:00:00.0", "9999-12-01 23:59:00.000"
+
+class com.gs.fw.common.mithra.test.domain.SaleAggregateData
+saleId, sellerId, priceDouble, priceInt, priceShort, priceLong, priceFloat, priceByte, priceBigDecimal
+1, 1, 1.0, 1, 1, 1, 1, 1, 1.12
+2, 1, 2.0, 2, 2, 2, 2, 2, 2.12
+3, 1, 3.0, 3, 3, 3, 3, 3, 4.12
+4, 2, 1.0, 1, 1, 1, 1, 1, 1.12
+5, 2, 1.0, 1, 1, 1, 1, 1, 1.12
+6, 3, 1.0, 1, 1, 1, 1, 1, 1.12
+
+class com.gs.fw.common.mithra.test.domain.Order
+orderId,orderDate,userId,description,state,trackingId
+1,"2004-01-12 00:00:00.0", 1, "First order", "In-Progress", "123"
+2,"2004-02-12 00:00:00.0", 1, "Second order", "In-Progress", "124"
+3,"2004-03-12 00:00:00.0", 1, "Third order", "In-Progress", "125"
+4,"2004-04-12 00:00:00.0", 2, "Fourth order, different user", "In-Progress", "126"
+55,"2004-04-12 00:00:00.0", 3, "Order number five", "Gummed up", "127"
+56,"2004-04-12 00:00:00.0", 3, "Sixth order, different user", "Gummed up", "128"
+57,"2004-04-12 00:00:00.0", 3, "Seventh order, different user", "Gummed up", "129"
+
+class com.gs.fw.common.mithra.test.domain.ParaDesk
+deskIdString,activeBoolean,sizeDouble,connectionLong,tagInt,statusChar,createTimestamp,locationByte,closedDate,maxFloat,minShort, bigDouble
+"rnd",true, 10.54, 1000000, 100, "O", "1981-06-08 02:01:00.0", 0,              "1981-06-08", 999999.9, 4545, -999.99
+"cap",true, 10032.23, 1000000, 100, "P", "9999-12-01 23:59:00.0", 0,           "1981-06-08", 6567567.75, 6745, 999.99
+"lsd",true, 4000000000, 1000000, 100, "A", "9999-12-01 23:59:00.0", 0,         "9999-12-01", 36546.43, 3545, 999.99
+"swp",true, 22342.33, 1000000, 100, "A", "1900-01-01 00:00:00.0", 0,           "9999-12-01", 4000000000, 20343, -999.99
+"usd",true, 43.23, 2000000, 100, "B", "9999-12-01 00:00:00.0", 0,             "1981-06-08", 23423.234234234, 100, null
+"gi2",true, 3022.45, 2000000, 100, "H", "1981-06-08 02:01:00.0", 0,            "1900-01-01", 8944654.344453, 2000, null
+"fma",true, 766234324234235.76, 2000000, 100, "T", "1981-06-08 02:01:00.0", 0, "1900-01-01", 2342345.35435345, 3000, 1.99
+"abc",false, 4000000000, 2000000, 100, "E", "9999-12-01 23:59:00.0", 0,       "1981-06-08", 999999.999999999, 4000, -1.99
+"lmn",true, 1564654.34, 1000000, 100, "T", "1981-06-08 02:01:00.0", 0,           "1981-06-08", 34543534.45345345, 2000, 0.99
+"ar",false, 4353453453534543.43, 2000000, 100, "R", "1981-06-08 02:01:00.0", 0, "9999-12-01", 4000000000, 2330, -0.99
+"rpl",true, 657567567.75, 2000000, 100, "R", "9999-12-01 23:59:00.0", 0,        "1981-06-08", -43536456.435345, 100, 2.12
+"gma",true, 4000000000, 3000000, 100, "Q", "1900-01-01 00:00:00.0", 0,        "1981-06-08", 6575667.75, 1200, -2.12
+"gnb",true, 67767352343242.3, 3000000, 100, "G", "1900-01-01 00:00:00.0", 0,    "1900-01-01", -43446546.3453453, 4343, null
+"qqq",false, 454445, 2000000, 100, "J", "1900-01-01 00:00:00.0", 0,             "1900-01-01", 6576584.3452, 100, null
+"nsq",true, 5464565234435.9, 1000000, 100, "M", "9999-12-01 00:00:00.0", 0,     "1981-06-08", 7657453.25324534, 3000, 999.99
+"nmr",true, 5464565234435.9, 1000000, 10, "M", "9999-12-01 00:00:00.0", 0,    "1981-06-08", 7657453.25324534, 3000, 999.99
+"fff",true, 5464565234435.9, 1000000, 5, "M", "9999-12-01 00:00:00.0", 0,       "1981-06-08", 7657453.25324534, 3000, -999.99
+"xyz",true, -10.54, 1000000, 5, "M", "9999-12-01 00:00:00.0", 0,                "1981-06-08", 7657453.25324534, 3000, 1.99
+"moh",true, -45, 1000000, 5, "M", "9999-12-01 00:00:00.0", 0,                   "1981-06-08", 7657453.25324534, 3000, -1.99
+"yus",true, -927, 1000000, -827, "M", "9999-12-01 00:00:00.0", 0,               "1981-06-08", 654.25, 4567, -1.99
+
+class com.gs.fw.common.mithra.test.domain.AllTypes
+id,booleanValue,byteValue,shortValue,charValue,intValue,longValue,floatValue,doubleValue,dateValue,timeValue,timestampValue,stringValue,byteArrayValue,nullableByteValue,nullableShortValue,nullableCharValue,nullableIntValue,nullableLongValue,nullableFloatValue,nullableDoubleValue,nullableDateValue,nullableTimeValue,nullableTimestampValue,nullableStringValue,nullableByteArrayValue
+9876,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-01-01", "03:03:03.333", "2007-01-01 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9877,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-02-01", "03:03:03.333", "2007-01-02 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9878,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-03-01", "03:03:03.333", "2007-01-03 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9879,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-04-01", "03:03:03.333", "2007-01-04 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9880,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-05-01", "03:03:03.333", "2007-01-05 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9881,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-06-01", "03:03:03.333", "2007-01-06 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9882,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-07-01", "03:03:03.333", "2007-01-07 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9883,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-08-01", "03:03:03.333", "2007-01-08 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9884,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-09-01", "03:03:03.333", "2007-01-09 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9885,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2007-10-01", "03:03:03.333", "2007-01-10 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+9480,true,100,30000,"a",2000000000,9000000000000000000,100.99, 100.99998888777, "2008-11-22", "03:03:03.333", "2008-10-14 01:01:01.999", "This is a test", "00010001B5BFB5BA00174E5954414D5350316E74616D735F70726F64",null, null, null, null, null, null, null, null, null, null, null, null
+
+class com.gs.fw.common.mithra.test.domain.alarm.AlarmCategory
+id, category, time, description
+1, 1, "10:30:59.011", "alarm 1"
+2, 1, "03:11:23.000", "alarm 2"
+3, 2, "10:30:59.011", "alarm 3"
+4, 2, "03:11:23.000", "alarm 4"
+5, 3, "10:30:59.011", "alarm 5"
+6, 3, "03:11:23.000", "alarm 6"
+7, 3, "01:02:02.003", "alarm 600"


### PR DESCRIPTION
Adds first-class Snowflake support via `SnowflakeDatabaseType`.

Related to goldmansachs/reladomo#264

## What & Why
- Provide a dedicated `SnowflakeDatabaseType` aligned with Snowflake semantics (no row-level locks, session-scoped temp tables, LIMIT syntax, etc.).

## Key changes
- CRUD works on Snowflake with vendor-specific semantics:
  - SELECT: uses `LIMIT (rowCount + 1)` for capped reads; `FOR UPDATE` ignored (no row-level locks).
  - UPDATE: batch/multi updates use `UPDATE … FROM` join with temp tables.
  - DELETE: WHERE-only deletes (Snowflake has no `DELETE … LIMIT`); no bulk-delete temp-table join in this PR.
  - INSERT: supported via batched prepared statements (configurable batch sizes).
- Temp tables: non-shared only — `CREATE TEMPORARY TABLE` (session-scoped). Shared temp tables are not supported on Snowflake.
- Test tables: `shouldCreateTestIndexes() == false` → skip PK/UNIQUE index creation (Snowflake has no traditional indexes).
- LIKE escaping: meta chars `{ '%', '_', '\\' }`.
- Type mappings aligned to Snowflake (`number`, `timestamp_ntz`, `binary`, etc.).

## Tests
- 78 tests pass locally; can add more vendor/Snowflake-specific tests.

## Backward compatibility
- Other database types unchanged.

## Environment
- OS: Windows 11 + WSL2 (Ubuntu 24.04.2 LTS, kernel 6.6.87.2-microsoft-standard-WSL2)
- JDK: OpenJDK 1.8.0_462 (build 1.8.0_462-8u462-ga~us1-0ubuntu2~24.04.2-b08)
- Snowflake JDBC: 3.26.1
- Runner: VS Code Java Debug + JUnit 4 (`org.junit.runner.JUnitCore`)
- JVM flags: `-Duser.timezone=UTC`

.vscode/launch.json:
{
  "type": "java",
  "name": "Debug Single Snowflake Test",
  "request": "launch",
  "mainClass": "org.junit.runner.JUnitCore",
  "args": ["com.gs.fw.common.mithra.test.TestSnowflakeGeneralTestCases"],
  "cwd": "${workspaceFolder}",
  "env": { "RELADOMO_HOME": "${workspaceFolder}" },
  "vmArgs": "-Duser.timezone=UTC"
}

## Tests
<img width="378" height="215" alt="image" src="https://github.com/user-attachments/assets/cb4ad4db-ff96-461e-9712-c1441b49bf96" />

Nov-26:
<img width="1096" height="403" alt="image" src="https://github.com/user-attachments/assets/ac7a8914-6786-4428-9e1f-152dcfcd30f9" />

